### PR TITLE
Clean names remove outer underscores

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -32,7 +32,7 @@ def _strip_underscores(df, strip_underscores=None):
 
     if strip_underscores in ['left', 'l']:
         df = df.rename(columns=lambda x: x.lstrip('_'))
-    elif strip_underscores in ['riaght', 'r']:
+    elif strip_underscores in ['right', 'r']:
         df = df.rename(columns=lambda x: x.rstrip('_'))
     elif strip_underscores == 'both' or strip_underscores is True:
         df = df.rename(columns=lambda x: x.strip('_'))

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -18,7 +18,9 @@ def _strip_underscores(df, strip_underscores=None):
         df = _strip_underscores(df, strip_underscores='left')
 
     :param df: The pandas DataFrame object.
-    :param strip_underscores: A str of either 'left', 'right' or 'both'.
+    :param strip_underscores: Removes the outer underscores from all column
+    names. Default None keeps outer underscores. Values can be either 'left',
+    'right' or 'both' or the respective shorthand 'l', 'r' and True.
     :returns: A pandas DataFrame.
     """
     underscore_options = [None, 'left', 'right', 'both', 'l', 'r', True]
@@ -57,7 +59,9 @@ def clean_names(df, strip_underscores=None):
         df = jn.DataFrame(df).clean_names()
 
     :param df: The pandas DataFrame object.
-    :param strip_underscores: A str of either 'left', 'right' or 'both'.
+    :param strip_underscores: Removes the outer underscores from all column
+    names. Default None keeps outer underscores. Values can be either 'left',
+    'right' or 'both' or the respective shorthand 'l', 'r' and True.
     :returns: A pandas DataFrame.
     """
     df = df.rename(
@@ -73,8 +77,7 @@ def clean_names(df, strip_underscores=None):
                            .replace('(', '_')
                            .replace(')', '_')
                            .replace('.', '_')
-
-                           )
+    )
 
     df = df.rename(columns=lambda x: re.sub('_+', '_', x))
     df = _strip_underscores(df, strip_underscores)
@@ -220,8 +223,8 @@ def get_features_targets(df, target_columns, feature_columns=None):
     else:
         if isinstance(target_columns, str):
             xcols = [c for c in df.columns if target_columns != c]
-        elif (isinstance(target_columns, list) or
-              isinstance(target_columns, tuple)):
+        elif (isinstance(target_columns, list)
+              or isinstance(target_columns, tuple)):
             xcols = [c for c in df.columns if c not in target_columns]
         X = df[xcols]
     return X, Y
@@ -320,8 +323,8 @@ def convert_excel_date(df, column):
     :param str column: A column name.
     :returns: A pandas DataFrame with corrected dates.
     """
-    df[column] = (pd.TimedeltaIndex(df[column], unit='d') +
-                  dt.datetime(1899, 12, 30))
+    df[column] = (pd.TimedeltaIndex(df[column], unit='d')
+                  + dt.datetime(1899, 12, 30))
     return df
 
 

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -18,9 +18,10 @@ def _strip_underscores(df, strip_underscores=None):
         df = _strip_underscores(df, strip_underscores='left')
 
     :param df: The pandas DataFrame object.
-    :param strip_underscores: Removes the outer underscores from all column
-    names. Default None keeps outer underscores. Values can be either 'left',
-    'right' or 'both' or the respective shorthand 'l', 'r' and True.
+    :param strip_underscores: (optional) Removes the outer underscores from all
+        column names. Default None keeps outer underscores. Values can be
+        either 'left', 'right' or 'both' or the respective shorthand 'l', 'r'
+        and True.
     :returns: A pandas DataFrame.
     """
     underscore_options = [None, 'left', 'right', 'both', 'l', 'r', True]
@@ -31,7 +32,7 @@ def _strip_underscores(df, strip_underscores=None):
 
     if strip_underscores in ['left', 'l']:
         df = df.rename(columns=lambda x: x.lstrip('_'))
-    elif strip_underscores in ['right', 'r']:
+    elif strip_underscores in ['riaght', 'r']:
         df = df.rename(columns=lambda x: x.rstrip('_'))
     elif strip_underscores == 'both' or strip_underscores is True:
         df = df.rename(columns=lambda x: x.strip('_'))
@@ -59,9 +60,10 @@ def clean_names(df, strip_underscores=None):
         df = jn.DataFrame(df).clean_names()
 
     :param df: The pandas DataFrame object.
-    :param strip_underscores: Removes the outer underscores from all column
-    names. Default None keeps outer underscores. Values can be either 'left',
-    'right' or 'both' or the respective shorthand 'l', 'r' and True.
+    :param strip_underscores: (optional) Removes the outer underscores from all
+        column names. Default None keeps outer underscores. Values can be
+        either 'left', 'right' or 'both' or the respective shorthand 'l', 'r'
+        and True.
     :returns: A pandas DataFrame.
     """
     df = df.rename(

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -161,8 +161,22 @@ def test_multiindex_clean_names_pipe(multiindex_dataframe):
     assert set(df.columns) == set(expected_columns)
 
 
-def test_clean_names_strip_underscores(multiindex_dataframe):
+def test_clean_names_strip_underscores_both(multiindex_dataframe):
     df = clean_names(multiindex_dataframe, strip_underscores='both')
+
+    levels = [
+        ['a', 'bell_chart', 'decorated_elephant'],
+        ['b', 'normal_distribution', 'r_i_p_rhino']
+    ]
+
+    labels = [[1, 0, 2], [1, 0, 2]]
+
+    expected_columns = pd.MultiIndex(levels=levels, labels=labels)
+    assert set(df.columns) == set(expected_columns)
+
+
+def test_clean_names_strip_underscores_true(multiindex_dataframe):
+    df = clean_names(multiindex_dataframe, strip_underscores=True)
 
     levels = [
         ['a', 'bell_chart', 'decorated_elephant'],
@@ -189,9 +203,38 @@ def test_clean_names_strip_underscores_right(multiindex_dataframe):
     assert set(df.columns) == set(expected_columns)
 
 
+def test_clean_names_strip_underscores_r(multiindex_dataframe):
+    df = clean_names(multiindex_dataframe, strip_underscores='r')
+
+    levels = [
+        ['a', 'bell_chart', 'decorated_elephant'],
+        ['b', 'normal_distribution', 'r_i_p_rhino']
+    ]
+
+    labels = [[1, 0, 2], [1, 0, 2]]
+
+    expected_columns = pd.MultiIndex(levels=levels, labels=labels)
+    assert set(df.columns) == set(expected_columns)
+
+
 def test_clean_names_strip_underscores_left(multiindex_dataframe):
     df = multiindex_dataframe.rename(columns=lambda x: '_' + x)
     df = clean_names(multiindex_dataframe, strip_underscores='left')
+
+    levels = [
+        ['a', 'bell_chart', 'decorated_elephant'],
+        ['b', 'normal_distribution', 'r_i_p_rhino_']
+    ]
+
+    labels = [[1, 0, 2], [1, 0, 2]]
+
+    expected_columns = pd.MultiIndex(levels=levels, labels=labels)
+    assert set(df.columns) == set(expected_columns)
+
+
+def test_clean_names_strip_underscores_l(multiindex_dataframe):
+    df = multiindex_dataframe.rename(columns=lambda x: '_' + x)
+    df = clean_names(multiindex_dataframe, strip_underscores='l')
 
     levels = [
         ['a', 'bell_chart', 'decorated_elephant'],

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -173,3 +173,32 @@ def test_clean_names_strip_underscores(multiindex_dataframe):
 
     expected_columns = pd.MultiIndex(levels=levels, labels=labels)
     assert set(df.columns) == set(expected_columns)
+
+
+def test_clean_names_strip_underscores_right(multiindex_dataframe):
+    df = clean_names(multiindex_dataframe, strip_underscores='right')
+
+    levels = [
+        ['a', 'bell_chart', 'decorated_elephant'],
+        ['b', 'normal_distribution', 'r_i_p_rhino']
+    ]
+
+    labels = [[1, 0, 2], [1, 0, 2]]
+
+    expected_columns = pd.MultiIndex(levels=levels, labels=labels)
+    assert set(df.columns) == set(expected_columns)
+
+
+def test_clean_names_strip_underscores_left(multiindex_dataframe):
+    df = multiindex_dataframe.rename(columns=lambda x: '_' + x)
+    df = clean_names(multiindex_dataframe, strip_underscores='left')
+
+    levels = [
+        ['a', 'bell_chart', 'decorated_elephant'],
+        ['b', 'normal_distribution', 'r_i_p_rhino_']
+    ]
+
+    labels = [[1, 0, 2], [1, 0, 2]]
+
+    expected_columns = pd.MultiIndex(levels=levels, labels=labels)
+    assert set(df.columns) == set(expected_columns)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -159,3 +159,17 @@ def test_multiindex_clean_names_pipe(multiindex_dataframe):
 
     expected_columns = pd.MultiIndex(levels=levels, labels=labels)
     assert set(df.columns) == set(expected_columns)
+
+
+def test_clean_names_strip_underscores(multiindex_dataframe):
+    df = clean_names(multiindex_dataframe, strip_underscores='both')
+
+    levels = [
+        ['a', 'bell_chart', 'decorated_elephant'],
+        ['b', 'normal_distribution', 'r_i_p_rhino']
+    ]
+
+    labels = [[1, 0, 2], [1, 0, 2]]
+
+    expected_columns = pd.MultiIndex(levels=levels, labels=labels)
+    assert set(df.columns) == set(expected_columns)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -162,6 +162,7 @@ def test_multiindex_clean_names_pipe(multiindex_dataframe):
 
 
 def test_clean_names_strip_underscores_both(multiindex_dataframe):
+    df = multiindex_dataframe.rename(columns=lambda x: '_' + x)
     df = clean_names(multiindex_dataframe, strip_underscores='both')
 
     levels = [
@@ -176,6 +177,7 @@ def test_clean_names_strip_underscores_both(multiindex_dataframe):
 
 
 def test_clean_names_strip_underscores_true(multiindex_dataframe):
+    df = multiindex_dataframe.rename(columns=lambda x: '_' + x)
     df = clean_names(multiindex_dataframe, strip_underscores=True)
 
     levels = [


### PR DESCRIPTION
Adds kwarg to the function `clean_names` to strip leading and trailing underscores.

I did change some the syntax previously decided in the original issue. This was because I used pythons built-in `strip`, `lstrip` and `rstrip` string functions to remove the underscores. Therefore, it seemed more intuitive and "pythonic" to use `'left'` and `'right'` (and `'both'`).

I also added a shorthand `'l'` and `'r'` and `True`. This type of behaviour is common place in the Pandas API e.g. [here](https://github.com/pandas-dev/pandas/blob/v0.22.0/pandas/core/generic.py#L5319) and [here](https://github.com/pandas-dev/pandas/blob/a00154dcfe5057cb3fd86653172e74b6893e337d/pandas/io/parsers.py#L172), so this should be familiar to users.

We can also add `'end'` and `'start'` easily if these are still desired. Or, if you feel the above is not correct, I can just add exclusively `'both'`, `'end'` and `'start'` for a more terse/concise API.

Cheers

Closes #12 