### PR TITLE
Fix unicode error from single apostrophe

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import datetime as dt
 from functools import reduce
 
@@ -72,7 +73,7 @@ def clean_names(df, strip_underscores=None):
                            .replace('/', '_')
                            .replace(':', '_')
                            .replace("'", '')
-                           .replace('’', '')
+                           .replace(u'’', '')
                            .replace(',', '_')
                            .replace('?', '_')
                            .replace('-', '_')


### PR DESCRIPTION
I tried to run `pyjanitor` on my system and got the following error:

```
/Users/claire/anaconda/lib/python2.7/site-packages/pyjanitor-0.1.1-py2.7.egg/janitor/functions.pyc in <lambda>(x)
     74                            .replace(':', '_')
     75                            .replace("'", '')
---> 76                            .replace('’', '')
     77                            .replace(',', '_')
     78                            .replace('?', '_')

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)
```

I've gotten this before because of the funny single apostrophe, so was able to fix it by explicitly declaring utf-8 encoding. I'm using Python 2.7, so perhaps this isn't a problem in Python 3?

Also a side note that this edit fixes the error and passes the `flake8` tests, but running `py.test` gives me an error that seems (?) unrelated to my work:

```
(pyjanitor-dev) 15:41-claire:~/github/pyjanitor$ py.test
======================== test session starts =========================
platform darwin -- Python 3.6.5, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
rootdir: /Users/claire/github/pyjanitor, inifile:
collected 0 items / 1 errors                                         

=============================== ERRORS ===============================
______________ ERROR collecting tests/test_functions.py ______________
ImportError while importing test module '/Users/claire/github/pyjanitor/tests/test_functions.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/test_functions.py:5: in <module>
    import janitor as jn
E   ModuleNotFoundError: No module named 'janitor'
!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!
====================== 1 error in 0.56 seconds =======================
```