### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-pytest==3.4.2
-pandas==0.23.1
-numpy==1.14.1
-setuptools==38.5.2
+pytest>=3.4.2
+pandas>=0.23.1
+numpy>=1.14.1
+setuptools>=38.5.2
 sphinxcontrib-fulltoc==1.2.0
 scikit-learn==0.19.1
+xlrd>=0.9.0


### PR DESCRIPTION
Update working requirement versions
pandas.read_excel requires xlrd>=0.9.0

Pytested with:
pytest==3.6.3
pandas==0.23.3
numpy==1.14.5
setuptools==39.1.0
sphinxcontrib-fulltoc==1.2.0
scikit-learn==0.19.1
xlrd==1.1.0