### PR TITLE
Rework pandas flavour

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.1.3
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.2.0
 commit = False
 tag = False
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,8 @@
+# .readthedocs.yml
+
+build:
+  image: latest
+
+python:
+  version: 3.6
+  setup_py_install: true

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,17 @@ The idea behind the API is two-fold:
 - Copy the R package function names, but enable Pythonic use with method chaining or `pandas` piping.
 - Add other utility functions that make it easy to do data cleaning in `pandas`.
 
-As such, there are three ways to use the API. The first is the functional API.
+As such, there are four ways to use the API. The first, and most strongly recommended one, is to use janitor's functions as if they were native to pandas.
+
+.. code-block:: python
+
+    import pandas as pd
+    import janitor  # upon import, functions are registered as part of pandas.
+
+    df = pd.DataFrame(...)
+    df = df.clean_names().remove_empty()  # further method chaining possible.
+
+The second is the functional API.
 
 .. code-block:: python
 
@@ -62,8 +72,7 @@ As such, there are three ways to use the API. The first is the functional API.
     df = clean_names(df)
     df = remove_empty(df)
 
-
-The second is the wrapped `pandas` DataFrame.
+The third is the wrapped `pandas` DataFrame.
 
 .. code-block:: python
 
@@ -74,7 +83,7 @@ The second is the wrapped `pandas` DataFrame.
   df = jn.DataFrame(df)
   df.clean_names().remove_empty()... # method chaining possible
 
-The third is to use the `pipe()` method.
+The final way is to use the `pipe()` method.
 
 .. code-block:: python
 

--- a/janitor/__init__.py
+++ b/janitor/__init__.py
@@ -2,4 +2,4 @@ from .functions import *  # noqa: F403, F401
 from .dataframe import JanitorDataFrame as DataFrame  # noqa: F401
 from .dataframe import JanitorSeries as Series  # noqa: F401
 
-__version__ = '0.1.3'
+__version__ = '0.2.0'

--- a/janitor/__init__.py
+++ b/janitor/__init__.py
@@ -2,4 +2,4 @@ from .functions import *  # noqa: F403, F401
 from .dataframe import JanitorDataFrame as DataFrame  # noqa: F401
 from .dataframe import JanitorSeries as Series  # noqa: F401
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -12,7 +12,6 @@ from .errors import JanitorError
 import re
 
 
-# @pf.register_dataframe_method
 def _strip_underscores(df, strip_underscores=None):
     """
     Strip underscores from the beginning, end or both of the
@@ -43,7 +42,7 @@ def _strip_underscores(df, strip_underscores=None):
     return df
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def clean_names(df, strip_underscores=None, preserve_case=False):
     """
     Clean column names.
@@ -98,7 +97,7 @@ def clean_names(df, strip_underscores=None, preserve_case=False):
     return df
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def remove_empty(df):
     """
     Drop all rows and columns that are completely null.
@@ -132,7 +131,7 @@ def remove_empty(df):
     return df
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def get_dupes(df, columns=None):
     """
     Returns all duplicate rows.
@@ -161,7 +160,7 @@ def get_dupes(df, columns=None):
     return df[dupes == True]  # noqa: E712
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def encode_categorical(df, columns):
     """
     Encode the specified columns as categorical column in pandas.
@@ -200,7 +199,7 @@ def encode_categorical(df, columns):
     return df
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def label_encode(df, columns):
     """
     Convenience function to convert labels into numerical data.
@@ -244,7 +243,7 @@ def label_encode(df, columns):
     return df
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def get_features_targets(df, target_columns, feature_columns=None):
     """
     Get the features and targets as separate DataFrames/Series.
@@ -294,7 +293,7 @@ def get_features_targets(df, target_columns, feature_columns=None):
     return X, Y
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def rename_column(df, old, new):
     """
     Rename a column in place.
@@ -323,7 +322,7 @@ def rename_column(df, old, new):
     return df.rename(columns={old: new})
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def coalesce(df, columns, new_column_name):
     """
     Coalesces two or more columns of data in order of column names provided.
@@ -364,7 +363,7 @@ def coalesce(df, columns, new_column_name):
     return df
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def convert_excel_date(df, column):
     """
     Convert Excel's serial date format into Python datetime format.
@@ -395,7 +394,7 @@ def convert_excel_date(df, column):
     return df
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def fill_empty(df, columns, value):
     """
     Fill `NaN` values in specified columns with a given value.
@@ -434,7 +433,7 @@ def fill_empty(df, columns, value):
     return df
 
 
-# @pf.register_dataframe_method
+@pf.register_dataframe_method
 def expand_column(df, column, sep, concat=True):
     """
     Expand a categorical column with multiple labels into dummy-coded columns.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def requirements():
 
 setup(
     name='pyjanitor',
-    version='0.1.3',
+    version='0.2.0',
     description='Tools for cleaning pandas DataFrames',
     author='Eric J. Ma',
     author_email='ericmajinglong@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def requirements():
 
 setup(
     name='pyjanitor',
-    version='0.1.2',
+    version='0.1.3',
     description='Tools for cleaning pandas DataFrames',
     author='Eric J. Ma',
     author_email='ericmajinglong@gmail.com',

--- a/tests/test_df_registration.py
+++ b/tests/test_df_registration.py
@@ -1,0 +1,64 @@
+"""
+Author: Eric J. Ma
+Date: 18 July 2018
+
+The intent of these tests is to test that dataframe registration works.
+"""
+import pandas as pd
+import pytest
+import janitor
+
+
+@pytest.fixture
+def dataframe():
+    data = {
+        'a': [1, 2, 3],
+        'Bell__Chart': [1, 2, 3],
+        'decorated-elephant': [1, 2, 3],
+    }
+    df = pd.DataFrame(data)
+    return df
+
+
+def test_clean_names_registration(dataframe):
+    assert dataframe.__getattr__("clean_names")
+
+
+def test_remove_empty_registration(dataframe):
+    assert dataframe.__getattr__("remove_empty")
+
+
+def test_get_dupes_registration(dataframe):
+    assert dataframe.__getattr__("get_dupes")
+
+
+def test_encode_categorical_registration(dataframe):
+    assert dataframe.__getattr__("encode_categorical")
+
+
+def test_label_encode_registration(dataframe):
+    assert dataframe.__getattr__("label_encode")
+
+
+def test_get_features_targets_registration(dataframe):
+    assert dataframe.__getattr__("get_features_targets")
+
+
+def test_rename_column_registration(dataframe):
+    assert dataframe.__getattr__("rename_column")
+
+
+def test_coalesce_registration(dataframe):
+    assert dataframe.__getattr__("coalesce")
+
+
+def test_convert_excel_date_registration(dataframe):
+    assert dataframe.__getattr__("convert_excel_date")
+
+
+def test_fill_empty_registration(dataframe):
+    assert dataframe.__getattr__("fill_empty")
+
+
+def test_expand_column_registration(dataframe):
+    assert dataframe.__getattr__("expand_column")


### PR DESCRIPTION
Enables new way of using pandas dataframes: just import janitor, and all of janitor's functions are automatically attached and registered onto a pandas DataFrame object! No more wrapping :smile: