### PR TITLE
Add limit_column_characters function with tests

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Lead:
 With thanks to the following contributors:
 
 - `@JoshuaC3 <https://github.com/ericmjl/pyjanitor/pulls?q=is%3Apr+author%3AJoshuaC3>`_
+- `@szuckerman <https://github.com/ericmjl/pyjanitor/pulls?q=is%3Apr+author%3Aszuckerman>`_

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -36,7 +36,9 @@ def _strip_underscores(df, strip_underscores=None):
     """
     underscore_options = [None, "left", "right", "both", "l", "r", True]
     if strip_underscores not in underscore_options:
-        raise JanitorError(f"strip_underscores must be one of: {underscore_options}")
+        raise JanitorError(
+            f"strip_underscores must be one of: {underscore_options}"
+        )
 
     if strip_underscores in ["left", "l"]:
         df = df.rename(columns=lambda x: x.lstrip("_"))
@@ -455,14 +457,14 @@ def fill_empty(df, columns, value):
     """
     if isinstance(columns, list) or isinstance(columns, tuple):
         for col in columns:
-            assert col in df.columns, "{col} missing from dataframe columns!".format(
-                col=col
-            )
+            assert (
+                col in df.columns
+            ), "{col} missing from dataframe columns!".format(col=col)
             df[col] = df[col].fillna(value)
     else:
-        assert columns in df.columns, "{col} missing from dataframe columns!".format(
-            col=columns
-        )
+        assert (
+            columns in df.columns
+        ), "{col} missing from dataframe columns!".format(col=columns)
         df[columns] = df[columns].fillna(value)
 
     return df
@@ -506,7 +508,9 @@ def expand_column(df, column, sep, concat=True):
 
 
 @pf.register_dataframe_method
-def concatenate_columns(df, columns: list, new_column_name: str, sep: str = "-"):
+def concatenate_columns(
+    df, columns: list, new_column_name: str, sep: str = "-"
+):
     """
     Concatenates the set of columns into a single column.
 
@@ -591,7 +595,9 @@ def deconcatenate_column(df, column: str, new_column_names: list, sep: str):
 
 
 @pf.register_dataframe_method
-def filter_string(df, column: str, search_string: str, complement: bool = False):
+def filter_string(
+    df, column: str, search_string: str, complement: bool = False
+):
     """
     Filter a string-based column according to whether it contains a substring.
 
@@ -801,7 +807,9 @@ def limit_column_characters(df, column_length: int, col_separator: str = "_"):
 
     """
 
-    assert isinstance(column_length, int), "`column_length` must be an integer!"
+    assert isinstance(
+        column_length, int
+    ), "`column_length` must be an integer!"
     assert isinstance(col_separator, str), "`col_separator` must be a string!"
 
     col_names = df.columns
@@ -820,7 +828,9 @@ def limit_column_characters(df, column_length: int, col_separator: str = "_"):
     final_col_names = []
     for idx, col_name in enumerate(col_names):
         if col_name_count[idx] > 0:
-            col_name_to_append = col_name + col_separator + str(col_name_count[idx])
+            col_name_to_append = (
+                col_name + col_separator + str(col_name_count[idx])
+            )
             final_col_names.append(col_name_to_append)
         else:
             final_col_names.append(col_name)

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -36,9 +36,7 @@ def _strip_underscores(df, strip_underscores=None):
     """
     underscore_options = [None, "left", "right", "both", "l", "r", True]
     if strip_underscores not in underscore_options:
-        raise JanitorError(
-            f"strip_underscores must be one of: {underscore_options}"
-        )
+        raise JanitorError(f"strip_underscores must be one of: {underscore_options}")
 
     if strip_underscores in ["left", "l"]:
         df = df.rename(columns=lambda x: x.lstrip("_"))
@@ -457,16 +455,12 @@ def fill_empty(df, columns, value):
     """
     if isinstance(columns, list) or isinstance(columns, tuple):
         for col in columns:
-            assert (
-                col in df.columns
-            ), "{col} missing from dataframe columns!".format(
+            assert col in df.columns, "{col} missing from dataframe columns!".format(
                 col=col
             )
             df[col] = df[col].fillna(value)
     else:
-        assert (
-            columns in df.columns
-        ), "{col} missing from dataframe columns!".format(
+        assert columns in df.columns, "{col} missing from dataframe columns!".format(
             col=columns
         )
         df[columns] = df[columns].fillna(value)
@@ -512,9 +506,7 @@ def expand_column(df, column, sep, concat=True):
 
 
 @pf.register_dataframe_method
-def concatenate_columns(
-    df, columns: list, new_column_name: str, sep: str = "-"
-):
+def concatenate_columns(df, columns: list, new_column_name: str, sep: str = "-"):
     """
     Concatenates the set of columns into a single column.
 
@@ -599,9 +591,7 @@ def deconcatenate_column(df, column: str, new_column_names: list, sep: str):
 
 
 @pf.register_dataframe_method
-def filter_string(
-    df, column: str, search_string: str, complement: bool = False
-):
+def filter_string(df, column: str, search_string: str, complement: bool = False):
     """
     Filter a string-based column according to whether it contains a substring.
 
@@ -790,9 +780,8 @@ def add_column(df, colname: str, value):
     return df
 
 
-
 @pf.register_dataframe_method
-def limit_column_characters(df, column_length: int, col_separator: str = '_'):
+def limit_column_characters(df, column_length: int, col_separator: str = "_"):
     """
     Truncates column sizes to a specific length.
 
@@ -821,14 +810,12 @@ def limit_column_characters(df, column_length: int, col_separator: str = '_'):
     col_name_set = set(col_names)
     col_name_count = dict()
 
-
     for col_name_to_check in col_name_set:
         count = 0
         for idx, col_name in enumerate(col_names):
             if col_name_to_check == col_name:
                 col_name_count[idx] = count
-                count+=1
-
+                count += 1
 
     final_col_names = []
     for idx, col_name in enumerate(col_names):

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -788,3 +788,55 @@ def add_column(df, colname: str, value):
     assert isinstance(colname, str), "`colname` must be a string!"
     df[colname] = value
     return df
+
+
+
+@pf.register_dataframe_method
+def limit_column_characters(df, column_length: int, col_separator: str = '_'):
+    """
+    Truncates column sizes to a specific length.
+
+    Method chaining will truncate all columns to a given length and append
+    a given separator character with the index of duplicate columns, except
+    for the first distinct column name.
+
+    :param df: A pandas dataframe.
+    :param column_length: Character length for which to truncate all columns.
+      The column separator value and number for duplicate column name does not
+      contribute. Therefore, if all columns are truncated to 10 characters, the
+      first distinct column will be 10 characters and the remaining will be 12
+      characters (assuming a column separator of one character)
+    :param col_separator: The separator to use for counting distinct column values.
+      I think an underscore looks nicest, however a period is a common option as well.
+      Supply an empty string (i.e. '') to remove the separator.
+
+    """
+
+    assert isinstance(column_length, int), "`column_length` must be an integer!"
+    assert isinstance(col_separator, str), "`col_separator` must be a string!"
+
+    col_names = df.columns
+    col_names = [col_name[:column_length] for col_name in col_names]
+
+    col_name_set = set(col_names)
+    col_name_count = dict()
+
+
+    for col_name_to_check in col_name_set:
+        count = 0
+        for idx, col_name in enumerate(col_names):
+            if col_name_to_check == col_name:
+                col_name_count[idx] = count
+                count+=1
+
+
+    final_col_names = []
+    for idx, col_name in enumerate(col_names):
+        if col_name_count[idx] > 0:
+            col_name_to_append = col_name + col_separator + str(col_name_count[idx])
+            final_col_names.append(col_name_to_append)
+        else:
+            final_col_names.append(col_name)
+
+    df.columns = final_col_names
+    return df

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -459,12 +459,16 @@ def fill_empty(df, columns, value):
         for col in columns:
             assert (
                 col in df.columns
-            ), "{col} missing from dataframe columns!".format(col=col)
+            ), "{col} missing from dataframe columns!".format(
+                col=col
+            )
             df[col] = df[col].fillna(value)
     else:
         assert (
             columns in df.columns
-        ), "{col} missing from dataframe columns!".format(col=columns)
+        ), "{col} missing from dataframe columns!".format(
+            col=columns
+        )
         df[columns] = df[columns].fillna(value)
 
     return df
@@ -797,13 +801,15 @@ def limit_column_characters(df, column_length: int, col_separator: str = "_"):
 
     :param df: A pandas dataframe.
     :param column_length: Character length for which to truncate all columns.
-      The column separator value and number for duplicate column name does not
-      contribute. Therefore, if all columns are truncated to 10 characters, the
-      first distinct column will be 10 characters and the remaining will be 12
-      characters (assuming a column separator of one character)
-    :param col_separator: The separator to use for counting distinct column values.
-      I think an underscore looks nicest, however a period is a common option as well.
-      Supply an empty string (i.e. '') to remove the separator.
+        The column separator value and number for duplicate column name does
+        not contribute. Therefore, if all columns are truncated to 10
+        characters, the first distinct column will be 10 characters and the
+        remaining will be 12 characters (assuming a column separator of one
+        character).
+    :param col_separator: The separator to use for counting distinct column
+        values. I think an underscore looks nicest, however a period is a
+        common option as well. Supply an empty string (i.e. '') to remove the
+        separator.
 
     """
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -47,7 +47,7 @@ def dataframe_duplicate_columns():
         "cities": ["Cambridge", "Shanghai", "Basel"] * 3,
     }
     df = pd.DataFrame(data)
-    df.columns = ['first', 'first', 'second', 'second', 'first']
+    df.columns = ["first", "first", "second", "second", "first"]
     return df
 
 
@@ -73,37 +73,19 @@ def multiindex_dataframe():
 
 def test_clean_names_functional(dataframe):
     df = clean_names(dataframe)
-    expected_columns = [
-        "a",
-        "bell_chart",
-        "decorated_elephant",
-        "animals",
-        "cities",
-    ]
+    expected_columns = ["a", "bell_chart", "decorated_elephant", "animals", "cities"]
     assert set(df.columns) == set(expected_columns)
 
 
 def test_clean_names_method_chain(dataframe):
     df = dataframe.clean_names()
-    expected_columns = [
-        "a",
-        "bell_chart",
-        "decorated_elephant",
-        "animals",
-        "cities",
-    ]
+    expected_columns = ["a", "bell_chart", "decorated_elephant", "animals", "cities"]
     assert set(df.columns) == set(expected_columns)
 
 
 def test_clean_names_pipe(dataframe):
     df = dataframe.pipe(clean_names)
-    expected_columns = [
-        "a",
-        "bell_chart",
-        "decorated_elephant",
-        "animals",
-        "cities",
-    ]
+    expected_columns = ["a", "bell_chart", "decorated_elephant", "animals", "cities"]
     assert set(df.columns) == set(expected_columns)
 
 
@@ -180,9 +162,7 @@ def test_rename_column(dataframe):
 
 
 def test_coalesce():
-    df = pd.DataFrame(
-        {"a": [1, np.nan, 3], "b": [2, 3, 1], "c": [2, np.nan, 9]}
-    )
+    df = pd.DataFrame({"a": [1, np.nan, 3], "b": [2, 3, 1], "c": [2, np.nan, 9]})
 
     df = coalesce(df, ["a", "b", "c"], "a")
     assert df.shape == (3, 1)
@@ -207,9 +187,9 @@ def test_fill_empty_column_string(null_df):
 
 
 def test_single_column_label_encode():
-    df = pd.DataFrame(
-        {"a": ["hello", "hello", "sup"], "b": [1, 2, 3]}
-    ).label_encode(columns="a")
+    df = pd.DataFrame({"a": ["hello", "hello", "sup"], "b": [1, 2, 3]}).label_encode(
+        columns="a"
+    )
     assert "a_enc" in df.columns
 
 
@@ -390,10 +370,7 @@ def test_clean_names_preserve_case_true(multiindex_dataframe):
 
 
 def test_expand_column():
-    data = {
-        "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
-        "col2": [1, 2, 3, 4],
-    }
+    data = {"col1": ["A, B", "B, C, D", "E, F", "A, E, F"], "col2": [1, 2, 3, 4]}
 
     df = pd.DataFrame(data)
     expanded = expand_column(df, "col1", sep=", ", concat=False)
@@ -401,10 +378,7 @@ def test_expand_column():
 
 
 def test_expand_and_concat():
-    data = {
-        "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
-        "col2": [1, 2, 3, 4],
-    }
+    data = {"col1": ["A, B", "B, C, D", "E, F", "A, E, F"], "col2": [1, 2, 3, 4]}
 
     df = pd.DataFrame(data).expand_column("col1", sep=", ", concat=True)
     assert df.shape[1] == 8
@@ -412,24 +386,16 @@ def test_expand_and_concat():
 
 def test_concatenate_columns(dataframe):
     df = concatenate_columns(
-        dataframe,
-        columns=["a", "decorated-elephant"],
-        sep="-",
-        new_column_name="index",
+        dataframe, columns=["a", "decorated-elephant"], sep="-", new_column_name="index"
     )
     assert "index" in df.columns
 
 
 def test_deconcatenate_column(dataframe):
     df = concatenate_columns(
-        dataframe,
-        columns=["a", "decorated-elephant"],
-        sep="-",
-        new_column_name="index",
+        dataframe, columns=["a", "decorated-elephant"], sep="-", new_column_name="index"
     )
-    df = deconcatenate_column(
-        df, column="index", new_column_names=["A", "B"], sep="-"
-    )
+    df = deconcatenate_column(df, column="index", new_column_names=["A", "B"], sep="-")
     assert "A" in df.columns
     assert "B" in df.columns
 
@@ -476,26 +442,28 @@ def test_add_column(dataframe):
 
 def test_limit_column_characters(dataframe):
     df = dataframe.limit_column_characters(1)
-    assert df.columns[0] == 'a'
-    assert df.columns[1] == 'B'
-    assert df.columns[2] == 'd'
-    assert df.columns[3] == 'a_1'
-    assert df.columns[4] == 'c'
+    assert df.columns[0] == "a"
+    assert df.columns[1] == "B"
+    assert df.columns[2] == "d"
+    assert df.columns[3] == "a_1"
+    assert df.columns[4] == "c"
 
 
 def test_limit_column_characters_different_positions(dataframe_duplicate_columns):
     df = dataframe_duplicate_columns.limit_column_characters(3)
-    assert df.columns[0] == 'fir'
-    assert df.columns[1] == 'fir_1'
-    assert df.columns[2] == 'sec'
-    assert df.columns[3] == 'sec_1'
-    assert df.columns[4] == 'fir_2'
+    assert df.columns[0] == "fir"
+    assert df.columns[1] == "fir_1"
+    assert df.columns[2] == "sec"
+    assert df.columns[3] == "sec_1"
+    assert df.columns[4] == "fir_2"
 
 
-def test_limit_column_characters_different_positions_different_separator(dataframe_duplicate_columns):
-    df = dataframe_duplicate_columns.limit_column_characters(3, '.')
-    assert df.columns[0] == 'fir'
-    assert df.columns[1] == 'fir.1'
-    assert df.columns[2] == 'sec'
-    assert df.columns[3] == 'sec.1'
-    assert df.columns[4] == 'fir.2'
+def test_limit_column_characters_different_positions_different_separator(
+    dataframe_duplicate_columns
+):
+    df = dataframe_duplicate_columns.limit_column_characters(3, ".")
+    assert df.columns[0] == "fir"
+    assert df.columns[1] == "fir.1"
+    assert df.columns[2] == "sec"
+    assert df.columns[3] == "sec.1"
+    assert df.columns[4] == "fir.2"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -73,19 +73,37 @@ def multiindex_dataframe():
 
 def test_clean_names_functional(dataframe):
     df = clean_names(dataframe)
-    expected_columns = ["a", "bell_chart", "decorated_elephant", "animals", "cities"]
+    expected_columns = [
+        "a",
+        "bell_chart",
+        "decorated_elephant",
+        "animals",
+        "cities",
+    ]
     assert set(df.columns) == set(expected_columns)
 
 
 def test_clean_names_method_chain(dataframe):
     df = dataframe.clean_names()
-    expected_columns = ["a", "bell_chart", "decorated_elephant", "animals", "cities"]
+    expected_columns = [
+        "a",
+        "bell_chart",
+        "decorated_elephant",
+        "animals",
+        "cities",
+    ]
     assert set(df.columns) == set(expected_columns)
 
 
 def test_clean_names_pipe(dataframe):
     df = dataframe.pipe(clean_names)
-    expected_columns = ["a", "bell_chart", "decorated_elephant", "animals", "cities"]
+    expected_columns = [
+        "a",
+        "bell_chart",
+        "decorated_elephant",
+        "animals",
+        "cities",
+    ]
     assert set(df.columns) == set(expected_columns)
 
 
@@ -162,7 +180,9 @@ def test_rename_column(dataframe):
 
 
 def test_coalesce():
-    df = pd.DataFrame({"a": [1, np.nan, 3], "b": [2, 3, 1], "c": [2, np.nan, 9]})
+    df = pd.DataFrame(
+        {"a": [1, np.nan, 3], "b": [2, 3, 1], "c": [2, np.nan, 9]}
+    )
 
     df = coalesce(df, ["a", "b", "c"], "a")
     assert df.shape == (3, 1)
@@ -187,9 +207,9 @@ def test_fill_empty_column_string(null_df):
 
 
 def test_single_column_label_encode():
-    df = pd.DataFrame({"a": ["hello", "hello", "sup"], "b": [1, 2, 3]}).label_encode(
-        columns="a"
-    )
+    df = pd.DataFrame(
+        {"a": ["hello", "hello", "sup"], "b": [1, 2, 3]}
+    ).label_encode(columns="a")
     assert "a_enc" in df.columns
 
 
@@ -370,7 +390,10 @@ def test_clean_names_preserve_case_true(multiindex_dataframe):
 
 
 def test_expand_column():
-    data = {"col1": ["A, B", "B, C, D", "E, F", "A, E, F"], "col2": [1, 2, 3, 4]}
+    data = {
+        "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
+        "col2": [1, 2, 3, 4],
+    }
 
     df = pd.DataFrame(data)
     expanded = expand_column(df, "col1", sep=", ", concat=False)
@@ -378,7 +401,10 @@ def test_expand_column():
 
 
 def test_expand_and_concat():
-    data = {"col1": ["A, B", "B, C, D", "E, F", "A, E, F"], "col2": [1, 2, 3, 4]}
+    data = {
+        "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
+        "col2": [1, 2, 3, 4],
+    }
 
     df = pd.DataFrame(data).expand_column("col1", sep=", ", concat=True)
     assert df.shape[1] == 8
@@ -386,16 +412,24 @@ def test_expand_and_concat():
 
 def test_concatenate_columns(dataframe):
     df = concatenate_columns(
-        dataframe, columns=["a", "decorated-elephant"], sep="-", new_column_name="index"
+        dataframe,
+        columns=["a", "decorated-elephant"],
+        sep="-",
+        new_column_name="index",
     )
     assert "index" in df.columns
 
 
 def test_deconcatenate_column(dataframe):
     df = concatenate_columns(
-        dataframe, columns=["a", "decorated-elephant"], sep="-", new_column_name="index"
+        dataframe,
+        columns=["a", "decorated-elephant"],
+        sep="-",
+        new_column_name="index",
     )
-    df = deconcatenate_column(df, column="index", new_column_names=["A", "B"], sep="-")
+    df = deconcatenate_column(
+        df, column="index", new_column_names=["A", "B"], sep="-"
+    )
     assert "A" in df.columns
     assert "B" in df.columns
 
@@ -449,7 +483,9 @@ def test_limit_column_characters(dataframe):
     assert df.columns[4] == "c"
 
 
-def test_limit_column_characters_different_positions(dataframe_duplicate_columns):
+def test_limit_column_characters_different_positions(
+    dataframe_duplicate_columns
+):
     df = dataframe_duplicate_columns.limit_column_characters(3)
     assert df.columns[0] == "fir"
     assert df.columns[1] == "fir_1"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -38,6 +38,20 @@ def dataframe():
 
 
 @pytest.fixture
+def dataframe_duplicate_columns():
+    data = {
+        "a": [1, 2, 3] * 3,
+        "Bell__Chart": [1, 2, 3] * 3,
+        "decorated-elephant": [1, 2, 3] * 3,
+        "animals": ["rabbit", "leopard", "lion"] * 3,
+        "cities": ["Cambridge", "Shanghai", "Basel"] * 3,
+    }
+    df = pd.DataFrame(data)
+    df.columns = ['first', 'first', 'second', 'second', 'first']
+    return df
+
+
+@pytest.fixture
 def null_df():
     np.random.seed([3, 1415])
     df = pd.DataFrame(np.random.choice((1, np.nan), (10, 2)))
@@ -458,3 +472,30 @@ def test_add_column(dataframe):
     series = pd.Series([42] * len(dataframe))
     series.name = "fortytwo"
     pd.testing.assert_series_equal(df["fortytwo"], series)
+
+
+def test_limit_column_characters(dataframe):
+    df = dataframe.limit_column_characters(1)
+    assert df.columns[0] == 'a'
+    assert df.columns[1] == 'B'
+    assert df.columns[2] == 'd'
+    assert df.columns[3] == 'a_1'
+    assert df.columns[4] == 'c'
+
+
+def test_limit_column_characters_different_positions(dataframe_duplicate_columns):
+    df = dataframe_duplicate_columns.limit_column_characters(3)
+    assert df.columns[0] == 'fir'
+    assert df.columns[1] == 'fir_1'
+    assert df.columns[2] == 'sec'
+    assert df.columns[3] == 'sec_1'
+    assert df.columns[4] == 'fir_2'
+
+
+def test_limit_column_characters_different_positions_different_separator(dataframe_duplicate_columns):
+    df = dataframe_duplicate_columns.limit_column_characters(3, '.')
+    assert df.columns[0] == 'fir'
+    assert df.columns[1] == 'fir.1'
+    assert df.columns[2] == 'sec'
+    assert df.columns[3] == 'sec.1'
+    assert df.columns[4] == 'fir.2'


### PR DESCRIPTION
As per [issue 15](https://github.com/ericmjl/pyjanitor/issues/15) I've added a limit_column_characters function.

There's three tests; they should be sufficient.

I don't think we could have gone with the suggestion to use the df_column_uniquify function in [this stackoverflow answer](https://stackoverflow.com/a/44957247) since it will only work if the duplicate columns are next to each other. If they skip and repeat later, the count starts again.