### PR TITLE
Add round_to_fraction with tests and example

### DIFF
--- a/docs/round_to_fraction.rst
+++ b/docs/round_to_fraction.rst
@@ -1,0 +1,124 @@
+df.round_to_fraction()
+======================
+
+Description
+-----------
+
+This method modifies a column of floats to a nearest fraction, given a
+certain denominator.
+
+Parameters
+----------
+
+df
+~~
+
+A pandas dataframe.
+
+colname
+~~~~~~~
+
+The column which to apply the fraction transformation.
+
+denominator
+~~~~~~~~~~~
+
+The denominator of the fraction to round to. For example, ``2`` would
+values to the nearest half (i.e. ``1/2``).
+
+Setup
+-----
+
+.. code:: python
+
+    import pandas as pd
+    import janitor
+     
+    data_dict = {
+        "a": [1.23452345, 2.456234, 3.2346125] * 3,
+        "Bell__Chart": [1/3, 2/7, 3/2] * 3,
+        "decorated-elephant": [1/234, 2/13, 3/167] * 3,
+        "animals": ["rabbit", "leopard", "lion"] * 3,
+        "cities": ["Cambridge", "Shanghai", "Basel"] * 3,
+    }
+
+Example1: Rounding the first column to the nearest half
+-------------------------------------------------------
+
+.. code:: python
+
+    example_dataframe = pd.DataFrame(data_dict)
+     
+    example_dataframe.round_to_fraction('a', 2)
+
+Output
+~~~~~~
+
+::
+
+         a  Bell__Chart  decorated-elephant  animals     cities
+    0  1.0     0.333333            0.004274   rabbit  Cambridge
+    1  2.5     0.285714            0.153846  leopard   Shanghai
+    2  3.0     1.500000            0.017964     lion      Basel
+    3  1.0     0.333333            0.004274   rabbit  Cambridge
+    4  2.5     0.285714            0.153846  leopard   Shanghai
+    5  3.0     1.500000            0.017964     lion      Basel
+    6  1.0     0.333333            0.004274   rabbit  Cambridge
+    7  2.5     0.285714            0.153846  leopard   Shanghai
+    8  3.0     1.500000            0.017964     lion      Basel
+
+Example2: Rounding the first column to nearest third
+----------------------------------------------------
+
+.. code:: python
+
+
+    example_dataframe2 = pd.DataFrame(data_dict)
+     
+    example_dataframe2.limit_column_characters('a', 3)
+
+.. _output-1:
+
+Output
+~~~~~~
+
+::
+
+              a  Bell__Chart  decorated-elephant  animals     cities
+    0  1.333333     0.333333            0.004274   rabbit  Cambridge
+    1  2.333333     0.285714            0.153846  leopard   Shanghai
+    2  3.333333     1.500000            0.017964     lion      Basel
+    3  1.333333     0.333333            0.004274   rabbit  Cambridge
+    4  2.333333     0.285714            0.153846  leopard   Shanghai
+    5  3.333333     1.500000            0.017964     lion      Basel
+    6  1.333333     0.333333            0.004274   rabbit  Cambridge
+    7  2.333333     0.285714            0.153846  leopard   Shanghai
+    8  3.333333     1.500000            0.017964     lion      Basel
+
+Example3: Rounding the first column to the nearest third and rounding each value to the 10,000th place
+------------------------------------------------------------------------------------------------------
+
+.. code:: python
+
+
+    example_dataframe2 = pd.DataFrame(data_dict)
+     
+    example_dataframe2.limit_column_characters('a', 3, 4)
+
+.. _output-2:
+
+Output
+~~~~~~
+
+::
+
+            a  Bell__Chart  decorated-elephant  animals     cities
+    0  1.3333     0.333333            0.004274   rabbit  Cambridge
+    1  2.3333     0.285714            0.153846  leopard   Shanghai
+    2  3.3333     1.500000            0.017964     lion      Basel
+    3  1.3333     0.333333            0.004274   rabbit  Cambridge
+    4  2.3333     0.285714            0.153846  leopard   Shanghai
+    5  3.3333     1.500000            0.017964     lion      Basel
+    6  1.3333     0.333333            0.004274   rabbit  Cambridge
+    7  2.3333     0.285714            0.153846  leopard   Shanghai
+    8  3.3333     1.500000            0.017964     lion      Basel

--- a/examples/round_to_fraction.md
+++ b/examples/round_to_fraction.md
@@ -69,7 +69,7 @@ example_dataframe2.limit_column_characters('a', 3)
     7  2.333333     0.285714            0.153846  leopard   Shanghai
     8  3.333333     1.500000            0.017964     lion      Basel
 
-## Example3: Rounding the first column to the nearest third and rounding each value to the 10,000th place 
+## Example 3: Rounding the first column to the nearest third and rounding each value to the 10,000th place 
 
 ```python
 

--- a/examples/round_to_fraction.md
+++ b/examples/round_to_fraction.md
@@ -27,7 +27,7 @@ data_dict = {
 }
 ```
 
-## Example1: Rounding the first column to the nearest half
+## Example 1: Rounding the first column to the nearest half
  ```python
 example_dataframe = pd.DataFrame(data_dict)
   

--- a/examples/round_to_fraction.md
+++ b/examples/round_to_fraction.md
@@ -1,0 +1,92 @@
+# df.round_to_fraction()
+
+## Description
+This method modifies a column of floats to a nearest fraction, given a certain denominator.
+
+## Parameters
+### df
+A pandas dataframe.
+     
+### colname
+The column which to apply the fraction transformation.
+     
+### denominator
+The denominator of the fraction to round to. For example, `2`  would values to the nearest half (i.e. `1/2`).
+
+## Setup
+```python
+import pandas as pd
+import janitor
+ 
+data_dict = {
+    "a": [1.23452345, 2.456234, 3.2346125] * 3,
+    "Bell__Chart": [1/3, 2/7, 3/2] * 3,
+    "decorated-elephant": [1/234, 2/13, 3/167] * 3,
+    "animals": ["rabbit", "leopard", "lion"] * 3,
+    "cities": ["Cambridge", "Shanghai", "Basel"] * 3,
+}
+```
+
+## Example1: Rounding the first column to the nearest half
+ ```python
+example_dataframe = pd.DataFrame(data_dict)
+  
+example_dataframe.round_to_fraction('a', 2)
+```
+
+### Output
+
+         a  Bell__Chart  decorated-elephant  animals     cities
+    0  1.0     0.333333            0.004274   rabbit  Cambridge
+    1  2.5     0.285714            0.153846  leopard   Shanghai
+    2  3.0     1.500000            0.017964     lion      Basel
+    3  1.0     0.333333            0.004274   rabbit  Cambridge
+    4  2.5     0.285714            0.153846  leopard   Shanghai
+    5  3.0     1.500000            0.017964     lion      Basel
+    6  1.0     0.333333            0.004274   rabbit  Cambridge
+    7  2.5     0.285714            0.153846  leopard   Shanghai
+    8  3.0     1.500000            0.017964     lion      Basel
+
+## Example2: Rounding the first column to nearest third
+
+```python
+
+example_dataframe2 = pd.DataFrame(data_dict)
+ 
+example_dataframe2.limit_column_characters('a', 3)
+```
+
+### Output
+
+              a  Bell__Chart  decorated-elephant  animals     cities
+    0  1.333333     0.333333            0.004274   rabbit  Cambridge
+    1  2.333333     0.285714            0.153846  leopard   Shanghai
+    2  3.333333     1.500000            0.017964     lion      Basel
+    3  1.333333     0.333333            0.004274   rabbit  Cambridge
+    4  2.333333     0.285714            0.153846  leopard   Shanghai
+    5  3.333333     1.500000            0.017964     lion      Basel
+    6  1.333333     0.333333            0.004274   rabbit  Cambridge
+    7  2.333333     0.285714            0.153846  leopard   Shanghai
+    8  3.333333     1.500000            0.017964     lion      Basel
+
+## Example3: Rounding the first column to the nearest third and rounding each value to the 10,000th place 
+
+```python
+
+example_dataframe2 = pd.DataFrame(data_dict)
+ 
+example_dataframe2.limit_column_characters('a', 3, 4)
+```
+
+### Output
+
+            a  Bell__Chart  decorated-elephant  animals     cities
+    0  1.3333     0.333333            0.004274   rabbit  Cambridge
+    1  2.3333     0.285714            0.153846  leopard   Shanghai
+    2  3.3333     1.500000            0.017964     lion      Basel
+    3  1.3333     0.333333            0.004274   rabbit  Cambridge
+    4  2.3333     0.285714            0.153846  leopard   Shanghai
+    5  3.3333     1.500000            0.017964     lion      Basel
+    6  1.3333     0.333333            0.004274   rabbit  Cambridge
+    7  2.3333     0.285714            0.153846  leopard   Shanghai
+    8  3.3333     1.500000            0.017964     lion      Basel

--- a/examples/round_to_fraction.md
+++ b/examples/round_to_fraction.md
@@ -47,7 +47,7 @@ example_dataframe.round_to_fraction('a', 2)
     7  2.5     0.285714            0.153846  leopard   Shanghai
     8  3.0     1.500000            0.017964     lion      Basel
 
-## Example2: Rounding the first column to nearest third
+## Example 2: Rounding the first column to nearest third
 
 ```python
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -28,39 +28,12 @@ from janitor.errors import JanitorError
 def dataframe():
     data = {
         "a": [1, 2, 3] * 3,
-        "Bell__Chart": [1, 2, 3] * 3,
+        "Bell__Chart": [1.23452345, 2.456234, 3.2346125] * 3,
         "decorated-elephant": [1, 2, 3] * 3,
         "animals": ["rabbit", "leopard", "lion"] * 3,
         "cities": ["Cambridge", "Shanghai", "Basel"] * 3,
     }
     df = pd.DataFrame(data)
-    return df
-
-
-@pytest.fixture
-def dataframe_floats():
-    data = {
-        "a": [1.23452345, 2.456234, 3.2346125] * 3,
-        "Bell__Chart": [1 / 3, 2 / 7, 3 / 2] * 3,
-        "decorated-elephant": [1 / 234, 2 / 13, 3 / 167] * 3,
-        "animals": ["rabbit", "leopard", "lion"] * 3,
-        "cities": ["Cambridge", "Shanghai", "Basel"] * 3,
-    }
-    df = pd.DataFrame(data)
-    return df
-
-
-@pytest.fixture
-def dataframe_duplicate_columns():
-    data = {
-        "a": [1, 2, 3] * 3,
-        "Bell__Chart": [1, 2, 3] * 3,
-        "decorated-elephant": [1, 2, 3] * 3,
-        "animals": ["rabbit", "leopard", "lion"] * 3,
-        "cities": ["Cambridge", "Shanghai", "Basel"] * 3,
-    }
-    df = pd.DataFrame(data)
-    df.columns = ["first", "first", "second", "second", "first"]
     return df
 
 
@@ -496,10 +469,11 @@ def test_limit_column_characters(dataframe):
     assert df.columns[4] == "c"
 
 
-def test_limit_column_characters_different_positions(
-    dataframe_duplicate_columns
-):
-    df = dataframe_duplicate_columns.limit_column_characters(3)
+def test_limit_column_characters_different_positions(dataframe):
+    df = dataframe
+    df.columns = ["first", "first", "second", "second", "first"]
+    df.limit_column_characters(3)
+
     assert df.columns[0] == "fir"
     assert df.columns[1] == "fir_1"
     assert df.columns[2] == "sec"
@@ -508,9 +482,12 @@ def test_limit_column_characters_different_positions(
 
 
 def test_limit_column_characters_different_positions_different_separator(
-    dataframe_duplicate_columns
+    dataframe
 ):
-    df = dataframe_duplicate_columns.limit_column_characters(3, ".")
+    df = dataframe
+    df.columns = ["first", "first", "second", "second", "first"]
+    df.limit_column_characters(3, ".")
+
     assert df.columns[0] == "fir"
     assert df.columns[1] == "fir.1"
     assert df.columns[2] == "sec"
@@ -556,7 +533,7 @@ def test_add_column_iterator_repeat(dataframe):
 def test_row_to_names(dataframe):
     df = dataframe.row_to_names(2)
     assert df.columns[0] == 3
-    assert df.columns[1] == 3
+    assert df.columns[1] == 3.2346125
     assert df.columns[2] == 3
     assert df.columns[3] == "lion"
     assert df.columns[4] == "Basel"
@@ -565,7 +542,7 @@ def test_row_to_names(dataframe):
 def test_row_to_names_delete_this_row(dataframe):
     df = dataframe.row_to_names(2, remove_row=True)
     assert df.iloc[2, 0] == 1
-    assert df.iloc[2, 1] == 1
+    assert df.iloc[2, 1] == 1.23452345
     assert df.iloc[2, 2] == 1
     assert df.iloc[2, 3] == "rabbit"
     assert df.iloc[2, 4] == "Cambridge"
@@ -574,20 +551,20 @@ def test_row_to_names_delete_this_row(dataframe):
 def test_row_to_names_delete_above(dataframe):
     df = dataframe.row_to_names(2, remove_rows_above=True)
     assert df.iloc[0, 0] == 3
-    assert df.iloc[0, 1] == 3
+    assert df.iloc[0, 1] == 3.2346125
     assert df.iloc[0, 2] == 3
     assert df.iloc[0, 3] == "lion"
     assert df.iloc[0, 4] == "Basel"
 
 
-def test_round_to_nearest_half(dataframe_floats):
-    df = dataframe_floats.round_to_fraction("a", 2)
-    assert df.iloc[0, 0] == 1.0
-    assert df.iloc[1, 0] == 2.5
-    assert df.iloc[2, 0] == 3.0
-    assert df.iloc[3, 0] == 1.0
-    assert df.iloc[4, 0] == 2.5
-    assert df.iloc[5, 0] == 3.0
-    assert df.iloc[6, 0] == 1.0
-    assert df.iloc[7, 0] == 2.5
-    assert df.iloc[8, 0] == 3.0
+def test_round_to_nearest_half(dataframe):
+    df = dataframe.round_to_fraction("Bell__Chart", 2)
+    assert df.iloc[0, 1] == 1.0
+    assert df.iloc[1, 1] == 2.5
+    assert df.iloc[2, 1] == 3.0
+    assert df.iloc[3, 1] == 1.0
+    assert df.iloc[4, 1] == 2.5
+    assert df.iloc[5, 1] == 3.0
+    assert df.iloc[6, 1] == 1.0
+    assert df.iloc[7, 1] == 2.5
+    assert df.iloc[8, 1] == 3.0

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -38,6 +38,19 @@ def dataframe():
 
 
 @pytest.fixture
+def dataframe_floats():
+    data = {
+        "a": [1.23452345, 2.456234, 3.2346125] * 3,
+        "Bell__Chart": [1 / 3, 2 / 7, 3 / 2] * 3,
+        "decorated-elephant": [1 / 234, 2 / 13, 3 / 167] * 3,
+        "animals": ["rabbit", "leopard", "lion"] * 3,
+        "cities": ["Cambridge", "Shanghai", "Basel"] * 3,
+    }
+    df = pd.DataFrame(data)
+    return df
+
+
+@pytest.fixture
 def dataframe_duplicate_columns():
     data = {
         "a": [1, 2, 3] * 3,
@@ -565,3 +578,16 @@ def test_row_to_names_delete_above(dataframe):
     assert df.iloc[0, 2] == 3
     assert df.iloc[0, 3] == "lion"
     assert df.iloc[0, 4] == "Basel"
+
+
+def test_round_to_nearest_half(dataframe_floats):
+    df = dataframe_floats.round_to_fraction("a", 2)
+    assert df.iloc[0, 0] == 1.0
+    assert df.iloc[1, 0] == 2.5
+    assert df.iloc[2, 0] == 3.0
+    assert df.iloc[3, 0] == 1.0
+    assert df.iloc[4, 0] == 2.5
+    assert df.iloc[5, 0] == 3.0
+    assert df.iloc[6, 0] == 1.0
+    assert df.iloc[7, 0] == 2.5
+    assert df.iloc[8, 0] == 3.0


### PR DESCRIPTION
I added a `round_to_fraction` which rounds floats in a column to the nearest fraction.

I.e. you can round to the nearest half, third or 1/7th.

I saw it as a feature request for R's janitor: https://github.com/sfirke/janitor/issues/235