### PR TITLE
Added remove_special and case_type to clean names

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -52,7 +52,12 @@ def _strip_underscores(df, strip_underscores=None):
 
 
 @pf.register_dataframe_method
-def clean_names(df, strip_underscores=None, preserve_case=False):
+def clean_names(
+    df,
+    strip_underscores: str = None,
+    case_type: str = "lower",
+    remove_special: bool = False,
+):
     """
     Clean column names.
 
@@ -85,13 +90,26 @@ def clean_names(df, strip_underscores=None, preserve_case=False):
         column names. Default None keeps outer underscores. Values can be
         either 'left', 'right' or 'both' or the respective shorthand 'l', 'r'
         and True.
-    :param preserve_case: (optional) Allows you to choose whether to make all
-        column names lowercase, or to preserve current cases. Default False
+    :param case_type: (optional) Whether to make columns lower or uppercase.
+    Current case may be preserved with 'preserve'. Default 'lower'
         makes all characters lowercase.
+    :param remove_special: (optional) Remove special characters from columns.
+        Only letters, numbers and underscores are preserved.
     :returns: A pandas DataFrame.
     """
-    if preserve_case is False:
-        df = df.rename(columns=lambda x: x.lower())
+
+    assert case_type.lower() in {
+        "preserve",
+        "upper",
+        "lower",
+    }, "case_type argument must be one of ('preserve', 'upper', 'lower')"
+
+    if case_type.lower() != "preserve":
+        if case_type.lower() == "upper":
+            df = df.rename(columns=lambda x: x.upper())
+
+        elif case_type.lower() == "lower":
+            df = df.rename(columns=lambda x: x.lower())
 
     df = df.rename(
         columns=lambda x: x.replace(" ", "_")
@@ -106,6 +124,12 @@ def clean_names(df, strip_underscores=None, preserve_case=False):
         .replace(")", "_")
         .replace(".", "_")
     )
+
+    def _remove_special(col):
+        return "".join(item for item in col if item.isalnum() or "_" in item)
+
+    if remove_special:
+        df = df.rename(columns=_remove_special)
 
     df = df.rename(columns=lambda x: re.sub("_+", "_", x))
     df = _strip_underscores(df, strip_underscores)

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -900,7 +900,7 @@ def row_to_names(
 
 @pf.register_dataframe_method
 def round_to_fraction(
-    df, colname: str = None, denominator: int = None, digits: float = np.inf
+    df, colname: str = None, denominator: float = None, digits: float = np.inf
 ):
     """
     Round all values in a column to a fraction.
@@ -915,6 +915,16 @@ def round_to_fraction(
     """
 
     assert isinstance(colname, str), "`colname` must be a string!"
+
+    if denominator:
+        assert isinstance(denominator, float) or isinstance(
+            denominator, int
+        ), "`denominator` must be a float or int!"
+
+    if digits:
+        assert isinstance(digits, float) or isinstance(
+            digits, int
+        ), "`digits` must be a float or int!"
 
     def _round_to_fraction(number, denominator, digits=np.inf):
         num = round(number * denominator, 0) / denominator

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -30,7 +30,7 @@ def dataframe():
         "a": [1, 2, 3] * 3,
         "Bell__Chart": [1.23452345, 2.456234, 3.2346125] * 3,
         "decorated-elephant": [1, 2, 3] * 3,
-        "animals": ["rabbit", "leopard", "lion"] * 3,
+        "animals@#$%^": ["rabbit", "leopard", "lion"] * 3,
         "cities": ["Cambridge", "Shanghai", "Basel"] * 3,
     }
     df = pd.DataFrame(data)
@@ -63,7 +63,7 @@ def test_clean_names_functional(dataframe):
         "a",
         "bell_chart",
         "decorated_elephant",
-        "animals",
+        "animals@#$%^",
         "cities",
     ]
     assert set(df.columns) == set(expected_columns)
@@ -75,7 +75,7 @@ def test_clean_names_method_chain(dataframe):
         "a",
         "bell_chart",
         "decorated_elephant",
-        "animals",
+        "animals@#$%^",
         "cities",
     ]
     assert set(df.columns) == set(expected_columns)
@@ -87,8 +87,32 @@ def test_clean_names_pipe(dataframe):
         "a",
         "bell_chart",
         "decorated_elephant",
+        "animals@#$%^",
+        "cities",
+    ]
+    assert set(df.columns) == set(expected_columns)
+
+
+def test_clean_names_special_characters(dataframe):
+    df = dataframe.clean_names(remove_special=True)
+    expected_columns = [
+        "a",
+        "bell_chart",
+        "decorated_elephant",
         "animals",
         "cities",
+    ]
+    assert set(df.columns) == set(expected_columns)
+
+
+def test_clean_names_uppercase(dataframe):
+    df = dataframe.clean_names(case_type="upper", remove_special=True)
+    expected_columns = [
+        "A",
+        "BELL_CHART",
+        "DECORATED_ELEPHANT",
+        "ANIMALS",
+        "CITIES",
     ]
     assert set(df.columns) == set(expected_columns)
 
@@ -127,7 +151,7 @@ def test_encode_categorical_missing_column(dataframe):
 
 def test_encode_categorical_missing_columns(dataframe):
     with pytest.raises(AssertionError):
-        dataframe.encode_categorical(["animals", "cities", "aloha"])
+        dataframe.encode_categorical(["animals@#$%^", "cities", "aloha"])
 
 
 def test_encode_categorical_invalid_input(dataframe):
@@ -145,7 +169,7 @@ def test_get_features_targets(dataframe):
 def test_get_features_targets_multi_features(dataframe):
     dataframe = dataframe.clean_names()
     X, y = dataframe.get_features_targets(
-        feature_columns=["animals", "cities"], target_columns="bell_chart"
+        feature_columns=["animals@#$%^", "cities"], target_columns="bell_chart"
     )
     assert X.shape == (9, 2)
     assert y.shape == (9,)
@@ -161,7 +185,7 @@ def test_get_features_target_multi_columns(dataframe):
 def test_rename_column(dataframe):
     df = dataframe.clean_names().rename_column("a", "index")
     assert set(df.columns) == set(
-        ["index", "bell_chart", "decorated_elephant", "animals", "cities"]
+        ["index", "bell_chart", "decorated_elephant", "animals@#$%^", "cities"]
     )  # noqa: E501
 
 
@@ -362,7 +386,7 @@ def test_incorrect_strip_underscores(multiindex_dataframe):
 
 def test_clean_names_preserve_case_true(multiindex_dataframe):
     df = multiindex_dataframe.rename(columns=lambda x: "_" + x)
-    df = clean_names(multiindex_dataframe, preserve_case=True)
+    df = clean_names(multiindex_dataframe, case_type="preserve")
 
     levels = [
         ["a", "Bell_Chart", "decorated_elephant"],
@@ -421,7 +445,7 @@ def test_deconcatenate_column(dataframe):
 
 
 def test_filter_string(dataframe):
-    df = filter_string(dataframe, column="animals", search_string="bbit")
+    df = filter_string(dataframe, column="animals@#$%^", search_string="bbit")
     assert len(df) == 3
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -211,8 +211,8 @@ def test_reorder_columns(dataframe):
 
     # when columns are list & not all columns of DataFrame are included
     assert all(
-        dataframe.reorder_columns(["animals", "Bell__Chart"]).columns
-        == ["animals", "Bell__Chart", "a", "decorated-elephant", "cities"]
+        dataframe.reorder_columns(["animals@#$%^", "Bell__Chart"]).columns
+        == ["animals@#$%^", "Bell__Chart", "a", "decorated-elephant", "cities"]
     )
 
 


### PR DESCRIPTION
I added a few parameters to the clean_names method. Namely:

1. I added a `remove_special` parameter that removes all special characters and only retains letters, numbers and underscores.
2. I changed `preserve_case` to `case_type`. This way I was able to add an 'upper' option (I like uppercase column names). This also allows it to be more extensible in the future if you want to add camelCase, Title_Case, etc.

These should close out Issue #15, except that there still isn't an option to choose the character spaces should be changed to. I think they should always be underscores, though, and the current default is fine.