### PR TITLE
Suppress user warning

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -140,7 +140,7 @@ def clean_names(
 
     # Store the original column names, if enabled by user
     if preserve_original_columns:
-        df.original_columns = original_column_names
+        df.__dict__['original_columns'] = original_column_names
     return df
 
 


### PR DESCRIPTION
UserWarning: Pandas doesn't allow columns to be created via a new attribute name

This PR resolves issue #68 

# PR Checklist

Please ensure that you have done the following:

1. [ ] PR in from a fork off your branch. Do not PR from <your_username>:master, but rather from <your_username>:<branch_name>.
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.rst`.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [ ] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - pycodestyle checkin
    - running the test suite
    - docs build

## Code Changes

If you are adding code changes, please ensure the following:

- [ ] Ensure that you have added tests.
- [ ] Run all tests (`$ pytest .`) locally on your machine.
    - [ ] Check to ensure that test coverage covers the lines of code that you have added.
    - [ ] Ensure that all tests pass.

## Documentation Changes

If you are adding documentation changes, please ensure the following:

- [ ] Build the docs locally.
- [ ] View the docs to check that it renders correctly.

# PR Description

Please describe the changes proposed in the pull request:

- 
- 
- 

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
