### PR TITLE
Remove Py35 from Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ language: python
 matrix:
   include:
     - python: 3.5  # we don't actually use this
-      env: PYTHON_VERSION=3.5
-
-    - python: 3.5  # we don't actually use this
       env: PYTHON_VERSION=3.6
 
     - python: 3.5  # we don't actually use this


### PR DESCRIPTION
Follows policy of supporting last two versions of Python.