### PR TITLE
convert unix epoch time

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -549,6 +549,41 @@ def convert_matlab_date(df, column):
 
 
 @pf.register_dataframe_method
+def convert_unix_date(df, column):
+    """
+    Convert unix epoch time into Python datetime format.
+    Note that this ignores local tz and convert all
+    timestamps to naive datetime based on UTC!
+
+    Functional usage example:
+
+    .. code-block:: python
+        df = convert_unix_date(df, column='date')
+
+    Method chaining example:
+
+    .. code-block:: python
+        import pandas as pd
+        import janitor
+        df = pd.DataFrame(...).convert_unix_date('date')
+
+    :param df: A pandas DataFrame.
+    :param str column: A column name.
+    :returns: A pandas DataFrame with corrected dates.
+    """
+
+    def _conv(value):
+        try:
+            date = dt.datetime.utcfromtimestamp(value)
+        except ValueError:  # year of of rang means milliseconds.
+            date = dt.datetime.utcfromtimestamp(value / 1000)
+        return date
+
+    df[column] = df[column].astype(int).apply(_conv)
+    return df
+
+
+@pf.register_dataframe_method
 def fill_empty(df, columns, value):
     """
     Fill `NaN` values in specified columns with a given value.

--- a/tests/functions/test_convert_unix_date.py
+++ b/tests/functions/test_convert_unix_date.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+
+def test_convert_unix_date():
+    unix = [
+        "1284101485",
+        1_284_101_486,
+        "1284101487000",
+        1_284_101_488_000,
+        "1284101489",
+        "1284101490",
+        -2_147_483_648,
+        2_147_483_648,
+    ]
+    df = pd.DataFrame(unix, columns=["dates"]).convert_unix_date("dates")
+
+    assert df["dates"].dtype == "M8[ns]"

--- a/tests/test_df_registration.py
+++ b/tests/test_df_registration.py
@@ -61,6 +61,10 @@ def test_convert_matlab_date_registration(dataframe):
     assert dataframe.__getattr__("convert_matlab_date")
 
 
+def test_convert_unix_date_registration(dataframe):
+    assert dataframe.__getattr__("convert_unix_date")
+
+
 def test_fill_empty_registration(dataframe):
     assert dataframe.__getattr__("fill_empty")
 


### PR DESCRIPTION
This PR resolves #(put issue number here).

# PR Checklist

Please ensure that you have done the following:

1. [X] PR in from a fork off your branch. Do not PR from <your_username>:master, but rather from <your_username>:<branch_name>.
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.rst`.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [X] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - pycodestyle checkin
    - running the test suite
    - docs build

## Code Changes

If you are adding code changes, please ensure the following:

- [X] Ensure that you have added tests.
- [X] Run all tests (`$ pytest .`) locally on your machine.
    - [ ] Check to ensure that test coverage covers the lines of code that you have added.
    - [X] Ensure that all tests pass.

# PR Description

Please describe the changes proposed in the pull request:

Added a method to convert Unix epoch time to python `datetime` objects.
I understand that this is quite trivial and if you don't believe it is worth
adding it to `pyjanitor` feel free to close it.

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
