### PR TITLE
added checking for column name in rename_column function

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -377,6 +377,8 @@ def rename_column(df, old, new):
     :param str new: The new column name.
     :returns: A pandas DataFrame.
     """
+    if old not in df.columns:
+        raise ValueError(f"{old} not present in dataframe columns!")
     return df.rename(columns={old: new})
 
 

--- a/tests/biology/test_join_fasta.py
+++ b/tests/biology/test_join_fasta.py
@@ -9,7 +9,7 @@ def test_join_fasta(biodf):
     df = biodf.join_fasta(
         filename=TEST_DATA_DIR / "sequences.fasta",
         id_col="sequence_accession",
-        col_name="sequence"
+        col_name="sequence",
     )
 
     assert "sequence" in df.columns

--- a/tests/functions/test_add_columns.py
+++ b/tests/functions/test_add_columns.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pandas as pd
 import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
 
 from janitor.testing_utils.strategies import df_strategy
-from hypothesis import given, strategies as st, assume
-from hypothesis.extra.numpy import arrays
 
 
 @pytest.mark.test
@@ -12,7 +13,7 @@ from hypothesis.extra.numpy import arrays
 @given(
     df=df_strategy(),
     x_vals=st.floats(),
-    n_yvals=st.integers(min_value=0, max_value=100)
+    n_yvals=st.integers(min_value=0, max_value=100),
 )
 def test_add_columns(df, x_vals, n_yvals):
     """

--- a/tests/functions/test_rename_column.py
+++ b/tests/functions/test_rename_column.py
@@ -1,13 +1,22 @@
 import pytest
 from hypothesis import given
 
-from janitor.testing_utils.strategies import df_strategy
+from janitor.testing_utils.fixtures import dataframe
 
 
 @pytest.mark.functions
-@given(df=df_strategy())
-def test_rename_column(df):
-    df = df.clean_names().rename_column("a", "index")
+def test_rename_column(dataframe):
+    df = dataframe.clean_names().rename_column("a", "index")
     assert set(df.columns) == set(
         ["index", "bell_chart", "decorated_elephant", "animals@#$%^", "cities"]
     )
+    assert "a" not in set(df.columns)
+
+
+@pytest.mark.functions
+def test_rename_column_absent_column(dataframe):
+    """
+    rename_column should raise an error if the column is absent.
+    """
+    with pytest.raises(ValueError):
+        dataframe.clean_names().rename_column("bb", "index")


### PR DESCRIPTION
cc: @Zsailer 

This PR resolves #123.

# PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from <your_username>:master, but rather from <your_username>:<branch_name>.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [x] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - pycodestyle checkin
    - running the test suite
    - docs build

## Code Changes

If you are adding code changes, please ensure the following:

- [x] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [x] Check to ensure that test coverage covers the lines of code that you have added.
    - [x] Ensure that all tests pass.

# PR Description

Please describe the changes proposed in the pull request:

- Fixes #123, by introducing a check that "old" column name is present in the columns.

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
