### PR TITLE
update py3 dep to require 3.6 or later rather than specifically 3.6

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ channels:
 - conda-forge
 - ericmjl
 dependencies:
-- python=3.6
+- python >= 3.6
 - pandas >= 0.24.0
 - pytest
 - ipython


### PR DESCRIPTION
https://github.com/ericmjl/pyjanitor/issues/126

Just went ahead and did this because it was so trivial; not trying to bypass discussion.

@ericmjl @szuckerman 