### PR TITLE
Fix environment-dev.yml

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -25,6 +25,8 @@ dependencies:
 - pylint
 - biopython
 - doc8
+- nox
+- cairo
 - rdkit
 - pandas-flavor
 - mypy
@@ -32,6 +34,8 @@ dependencies:
 - black
 - hypothesis>=4.4.0
 - jupyterlab
+- xorg-libxrender
+- pip
 - pip:
   - sphinxcontrib-fulltoc
   - python-language-server[all]

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,6 +31,7 @@ dependencies:
 - pyflakes
 - black
 - hypothesis>=4.4.0
+- jupyterlab
 - pip:
   - sphinxcontrib-fulltoc
   - python-language-server[all]

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ channels:
 - conda-forge
 - ericmjl
 dependencies:
-- python=3.6
+- python >= 3.6
 - pandas >= 0.24.0
 - pytest
 - ipython


### PR DESCRIPTION
This PR resolves `environment-dev.yml` issues (not previously posted):

- JupyterLab should be a development dependency given we have example notebooks
- Python 3.6 was specifically getting pinned again (unintentional?)
- Known problem when RDKit is used on a system without X libraries being present:

https://sourceforge.net/p/rdkit/mailman/message/36341795/

This is relevant for people using Windows Subsystem for Linux.

> Hi,
>
>This looks like an error caused by the fact that the anaconda cairo builds
include a dependency on the system X libraries and you don't have X
installed.
>You can probably clear the problem up by installing the cairo build from
the RDKit channel. Run this inside the conda environment where you have the
RDKit installed:
>
>conda install -c rdkit nox
>conda install -c rdkit cairo
>
>-greg

Note that this was not sufficient for whatever reason; I had to install `xorg-libxrender` from `conda-forge`.

# Relevant Reviewers

- @ericmjl
- @szuckerman 
