### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ scikit-learn>=0.19.1
 xlrd>=0.9.0
 pandas-flavor==0.1.2
 biopython
+requests
+hypothesis>=4.4.0
+


### PR DESCRIPTION
Testing failed since I didn't have `hypothesis` and `requests` in my environment. `hypothesis` version was taken from the `.yml` file. `chemistry.py` also fails since I don't have `rdkit`, but that seems too niche and difficult to install, so I assume it's okay for those tests to fail for the rest of us.

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
