### PR TITLE
Fix naming conventions in expand_column()

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -631,7 +631,7 @@ def fill_empty(df, columns, value):
 
 
 @pf.register_dataframe_method
-def expand_column(df, column, sep, concat=True):
+def expand_column(df, sep, column_name=None, concat=True, **kwargs):
     """
     Expand a categorical column with multiple labels into dummy-coded columns.
 
@@ -641,7 +641,8 @@ def expand_column(df, column, sep, concat=True):
 
     .. code-block:: python
 
-        df = expand_column(df, column='col_name',
+        df = expand_column(df,
+                           column_name='col_name',
                            sep=', ')  # note space in sep
 
     Method chaining example:
@@ -650,21 +651,28 @@ def expand_column(df, column, sep, concat=True):
 
         import pandas as pd
         import janitor
-        df = pd.DataFrame(...).expand_column(df, column='col_name', sep=', ')
+        df = pd.DataFrame(...).expand_column(df,
+                                             column_name='col_name',
+                                             sep=', ')
 
     :param df: A pandas DataFrame.
-    :param column: A `str` indicating which column to expand.
+    :param column_name: A `str` indicating which column to expand.
     :param sep: The delimiter. Example delimiters include `|`, `, `, `,` etc.
     :param bool concat: Whether to return the expanded column concatenated to
         the original dataframe (`concat=True`), or to return it standalone
         (`concat=False`).
     """
-    expanded = df[column].str.get_dummies(sep=sep)
+    if kwargs and column_name is not None:
+        raise TypeError("Mixed usage of column and column_name")
+    if column_name is None:
+        warnings.warn("column is deprecated. You should use column_name.")
+        column_name = kwargs["column"]
+    expanded_df = df[column_name].str.get_dummies(sep=sep)
     if concat:
-        df = df.join(expanded)
+        df = df.join(expanded_df)
         return df
     else:
-        return expanded
+        return expanded_df
 
 
 @pf.register_dataframe_method

--- a/tests/functions/test_expand_column.py
+++ b/tests/functions/test_expand_column.py
@@ -10,8 +10,8 @@ def test_expand_column():
     }
 
     df = pd.DataFrame(data)
-    expanded = df.expand_column("col1", sep=", ", concat=False)
-    assert expanded.shape[1] == 6
+    expanded_df = df.expand_column(column_name="col1", sep=", ", concat=False)
+    assert expanded_df.shape[1] == 6
 
 
 @pytest.mark.functions
@@ -21,5 +21,7 @@ def test_expand_and_concat():
         "col2": [1, 2, 3, 4],
     }
 
-    df = pd.DataFrame(data).expand_column("col1", sep=", ", concat=True)
+    df = pd.DataFrame(data).expand_column(
+        column_name="col1", sep=", ", concat=True
+    )
     assert df.shape[1] == 8


### PR DESCRIPTION
This PR resolves #59. 

# PR Description


- Updates argument `column` to `column_name`
- Updates variable `expanded` to `expanded_df`
- Accommodates backwards compatibility by accepting old argument `column`

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
