### PR TITLE
Add skipif for tests you don't want locally

### DIFF
--- a/tests/chemistry/test_maccs_keys_fingerprint.py
+++ b/tests/chemistry/test_maccs_keys_fingerprint.py
@@ -1,8 +1,10 @@
+import importlib
 import pytest
 
 import janitor.chemistry  # noqa: disable=unused-import
 
 
+@pytest.mark.skipif(importlib.util.find_spec('rdkit') is None, reason="rdkit tests only required for CI")
 @pytest.mark.chemistry
 def test_maccs_keys_fingerprint(chemdf):
     maccs_keys = chemdf.smiles2mol("smiles", "mol").maccs_keys_fingerprint(

--- a/tests/chemistry/test_molecular_descriptors.py
+++ b/tests/chemistry/test_molecular_descriptors.py
@@ -1,8 +1,10 @@
+import importlib
 import pytest
 
 import janitor.chemistry  # noqa: disable=unused-import
 
 
+@pytest.mark.skipif(importlib.util.find_spec('rdkit') is None, reason="rdkit tests only required for CI")
 @pytest.mark.chemistry
 def test_molecular_descriptors(chemdf):
     mol_desc = chemdf.smiles2mol("smiles", "mol").molecular_descriptors("mol")

--- a/tests/chemistry/test_morgan_fingerprint.py
+++ b/tests/chemistry/test_morgan_fingerprint.py
@@ -1,8 +1,10 @@
+import importlib
 import pytest
 
 import janitor.chemistry  # noqa: disable=unused-import
 
 
+@pytest.mark.skipif(importlib.util.find_spec('rdkit') is None, reason="rdkit tests only required for CI")
 @pytest.mark.chemistry
 def test_morgan_fingerprint_counts(chemdf):
     morgans = chemdf.smiles2mol("smiles", "mol").morgan_fingerprint(
@@ -12,6 +14,7 @@ def test_morgan_fingerprint_counts(chemdf):
     assert (morgans.values >= 0).all()
 
 
+@pytest.mark.skipif(importlib.util.find_spec('rdkit') is None, reason="rdkit tests only required for CI")
 @pytest.mark.chemistry
 def test_morgan_fingerprint_bits(chemdf):
     morgans = chemdf.smiles2mol("smiles", "mol").morgan_fingerprint(

--- a/tests/chemistry/test_smiles2mol.py
+++ b/tests/chemistry/test_smiles2mol.py
@@ -1,6 +1,8 @@
+import importlib
 import pytest
 
 
+@pytest.mark.skipif(importlib.util.find_spec('rdkit') is None, reason="rdkit tests only required for CI")
 @pytest.mark.parametrize("progressbar", [None, "terminal"])
 @pytest.mark.chemistry
 def test_smiles2mol(chemdf, progressbar):


### PR DESCRIPTION
This PR resolves #193.

# PR Description

- Adds a `skipif` around tests that you want to be optional

If you have a preferred logic for skipping, I'm happy to modify. I've also paraphrased the reason from what @ericmjl was saying.

- @ericmjl
