### PR TITLE
[TST] Add test skip for checking Unix time on Windows

### DIFF
--- a/tests/functions/test_convert_unix_date.py
+++ b/tests/functions/test_convert_unix_date.py
@@ -5,8 +5,7 @@ import pandas as pd
 
 
 @pytest.mark.skipif(
-    os.name == 'nt',
-    reason="Skip *nix-specific tests on Windows",
+    os.name == "nt", reason="Skip *nix-specific tests on Windows"
 )
 def test_convert_unix_date():
     unix = [

--- a/tests/functions/test_convert_unix_date.py
+++ b/tests/functions/test_convert_unix_date.py
@@ -1,6 +1,13 @@
+import os
+
+import pytest
 import pandas as pd
 
 
+@pytest.mark.skipif(
+    os.name == 'nt',
+    reason="Skip *nix-specific tests on Windows",
+)
 def test_convert_unix_date():
     unix = [
         "1284101485",


### PR DESCRIPTION
This PR resolves #256 

# PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from <your_username>:master, but rather from <your_username>:<branch_name>.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [x] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - pycodestyle checkin
    - running the test suite
    - docs build

## Code Changes

If you are adding code changes, please ensure the following:

- [x] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [x] Check to ensure that test coverage covers the lines of code that you have added.
    - [x] Ensure that all tests pass.

# PR Description

Please describe the changes proposed in the pull request:

- Added in a `pytest.mark` to the Unix time check function to check for a Windows OS, per this [Stack Overflow article](https://stackoverflow.com/questions/1325581/how-do-i-check-if-im-running-on-windows-in-python)

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
