### PR TITLE
[ENH] Add decorator to cleanly alias deprecated arguments

### DIFF
--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -1,3 +1,7 @@
+import functools
+import warnings
+
+
 def import_message(submodule, package, installation):
     print(
         f"To use the janitor submodule {submodule}, you need to install \
@@ -23,3 +27,62 @@ def idempotent(func, df, *args, **kwargs):
     assert func(df, *args, **kwargs) == func(
         func(df, *args, **kwargs), *args, **kwargs
     )
+
+
+def deprecated_alias(**aliases):
+    """
+    Used as a decorator when deprecating old function argument names, while
+    keeping backwards compatibility.
+
+    Implementation is inspired from `StackOverflow`_.
+
+    .. _StackOverflow: https://stackoverflow.com/questions/49802412/how-to-implement-deprecation-in-python-with-argument-alias  # noqa: E501
+
+    Functional usage example:
+
+    .. code-block:: python
+
+        @deprecated_alias(a='alpha', b='beta')
+        def simple_sum(alpha, beta):
+            return alpha + beta
+
+    :param aliases: dictionary of aliases for a function's arguments
+    :return:
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            rename_kwargs(func.__name__, kwargs, aliases)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def rename_kwargs(func_name, kwargs, aliases):
+    """
+    Used to update deprecated argument names with new names. Throws a TypeError if
+    both arguments are provided, and warns if old alias is used.
+
+    Implementation is inspired from `StackOverflow`_.
+
+    .. _StackOverflow: https://stackoverflow.com/questions/49802412/how-to-implement-deprecation-in-python-with-argument-alias  # noqa: E501
+
+    :param func_name: name of decorated function
+    :param aliases: dictionary of aliases for a function's arguments
+    :param kwargs: arguments supplied to the method
+    :return:
+    """
+    for old_alias, new_alias in aliases.items():
+        if old_alias in kwargs:
+            if new_alias in kwargs:
+                raise TypeError(
+                    f"{func_name} received both {old_alias} and {new_alias}"
+                )
+            warnings.warn(
+                "{old_alias} is deprecated; use {new_alias}",
+                DeprecationWarning,
+            )
+            kwargs[new_alias] = kwargs.pop(old_alias)

--- a/tests/utils/test_deprecated_alias.py
+++ b/tests/utils/test_deprecated_alias.py
@@ -1,0 +1,39 @@
+import pytest
+
+from janitor.utils import deprecated_alias
+
+
+@deprecated_alias(a="alpha", b="beta")
+def simple_sum(alpha, beta):
+    gamma = alpha + beta
+    return gamma
+
+
+@pytest.mark.functions
+def test_old_aliases():
+    """
+    Using old aliases should  result in `DeprecationWarning`
+    """
+    with pytest.warns(DeprecationWarning):
+        simple_sum(a=2, b=6)
+
+
+@pytest.mark.functions
+def test_new_aliases():
+    """
+    Using new aliases should not result in errors or warnings
+    """
+    with pytest.warns(None) as record:
+        simple_sum(alpha=2, beta=6)
+    assert not record.list
+
+    assert simple_sum(alpha=2, beta=6)
+
+
+@pytest.mark.functions
+def test_mixed_aliases():
+    """
+    Using mixed aliases should result in errors
+    """
+    with pytest.raises(TypeError):
+        assert simple_sum(alpha=2, beta=6, a=5)


### PR DESCRIPTION
This PR addresses #59. 

# PR Checklist

Please ensure that you have done the following:

1. [X] PR in from a fork off your branch. Do not PR from <your_username>:master, but rather from <your_username>:<branch_name>.
2. [X] If you're not on the contributors list, add yourself to `AUTHORS.rst`.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [ ] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - [X] black formatting
    - [X] pycodestyle checkin
    - running the test suite
    - docs build

## Code Changes

If you are adding code changes, please ensure the following:

- [X] Ensure that you have added tests.
- [ ] Run all tests (`$ pytest .`) locally on your machine.
    - [X] Check to ensure that test coverage covers the lines of code that you have added.
    - [X] Ensure that all tests pass.

## Documentation Changes

If you are adding documentation changes, please ensure the following:

- [ ] Build the docs locally.
- [ ] View the docs to check that it renders correctly.

# PR Description

Please describe the changes proposed in the pull request:

- Added decorator to use when deprecating old function arguments

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
