### PR TITLE
[DOC] Use readthedocs YAML v2 for building docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,20 @@
 # .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-build:
-  image: latest
+# Required
+version: 2
 
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
-  setup_py_install: true
+  version: 3.7
+  install:
+    - requirements: requirements.txt
+    - requirements: requirements-dev.txt


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request: 

- Populated the YAML file with build instructions for readthedocs.
- In particular, ensured `requirements.txt` and `requirements-dev.txt` were both used to install packages.

**This PR resolves #222.**