### PR TITLE
[TST] add skipif for biology

### DIFF
--- a/tests/biology/test_join_fasta.py
+++ b/tests/biology/test_join_fasta.py
@@ -1,10 +1,15 @@
 import os
 
 import pytest
+import importlib
 
 import janitor.biology
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("Bio") is None,
+    reason="Biology tests relying on Biopython only required for CI",
+)
 @pytest.mark.biology
 def test_join_fasta(biodf):
     df = biodf.join_fasta(


### PR DESCRIPTION
Closes #330 

Test locally more easily by only removing the single `biopython` package with: `conda remove --force biopython`. You'll see the `skipif` message show up.

Please tag maintainers to review.

- @ericmjl
