### PR TITLE
[ENH] Refactor clean_names in functions

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -89,19 +89,7 @@ def clean_names(
         elif case_type.lower() == "lower":
             df = df.rename(columns=lambda x: x.lower())
 
-    df = df.rename(
-        columns=lambda x: x.replace(" ", "_")
-        .replace("/", "_")
-        .replace(":", "_")
-        .replace("'", "")
-        .replace("’", "")
-        .replace(",", "_")
-        .replace("?", "_")
-        .replace("-", "_")
-        .replace("(", "_")
-        .replace(")", "_")
-        .replace(".", "_")
-    )
+    df = df.rename(columns=_normalize_1)
 
     def _remove_special(col):
         return "".join(item for item in col if item.isalnum() or "_" in item)
@@ -122,6 +110,13 @@ FIXES = [
     (r"[ /:,?()\.-]", "_"),
     (r"['’]", ""),
 ]
+
+
+def _normalize_1(col_name):
+    result = col_name
+    for search, replace in FIXES:
+        result = re.sub(search, replace, result)
+    return result
 
 
 @pf.register_dataframe_method

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -106,10 +106,7 @@ def clean_names(
     return df
 
 
-FIXES = [
-    (r"[ /:,?()\.-]", "_"),
-    (r"['’]", ""),
-]
+FIXES = [(r"[ /:,?()\.-]", "_"), (r"['’]", "")]
 
 
 def _normalize_1(col_name):

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -118,6 +118,12 @@ def clean_names(
     return df
 
 
+FIXES = [
+    (r"[ /:,?()\.-]", "_"),
+    (r"['’]", ""),
+]
+
+
 @pf.register_dataframe_method
 def remove_empty(df: pd.DataFrame) -> pd.DataFrame:
     """


### PR DESCRIPTION
Refactors `clean_names` in functions to simplify by using the `re` module. This makes it easier to add more sophisticated column name normalizations later.

**This PR resolves #203 .**

The docs build part of `make check` is failing, so I ran `make docs` individually as listed in the Makefile but I am still getting the messages including:
- build succeeded, 15 warnings
- The message includes "WARNING: document isn't included in any toctree"

Please note that my code changes do not change the behavior and all tests pass.
@ericmjl please advise.