### PR TITLE
[INF] Test only on latest Python version

### DIFF
--- a/.azure-pipelines/pipeline-master.yml
+++ b/.azure-pipelines/pipeline-master.yml
@@ -9,8 +9,6 @@ jobs:
       matrix:
         py37:
           python.version: "3.7"
-        py36:
-          python.version: "3.6"
 
     pool:
       vmImage: ubuntu-16.04
@@ -28,8 +26,6 @@ jobs:
       matrix:
         py37:
           python.version: "3.7"
-        py36:
-          python.version: "3.6"
 
     pool:
       vmImage: macOS-10.14
@@ -52,8 +48,6 @@ jobs:
       matrix:
         py37:
           python.version: "3.7"
-        py36:
-          python.version: "3.6"
 
     pool:
       vmImage: vs2017-win2016


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request: 

- I have removed py36 from the build matrix. This should reduce the number of slots used per PR for CI builds, and hence speed up the time taken when there are multiple builds taking place. 