### PR TITLE
[DOC] Fix deprecation warning, deprecations and type hints

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -109,7 +109,7 @@ def clean_names(
 FIXES = [(r"[ /:,?()\.-]", "_"), (r"['’]", "")]
 
 
-def _normalize_1(col_name):
+def _normalize_1(col_name: str) -> str:
     result = col_name
     for search, replace in FIXES:
         result = re.sub(search, replace, result)
@@ -710,7 +710,7 @@ def concatenate_columns(
     column_names: Union[str, Iterable[str], Any],
     new_column_name,
     sep: str = "-",
-):
+) -> pd.DataFrame:
     """
     Concatenates the set of columns into a single column.
 
@@ -759,7 +759,7 @@ def deconcatenate_column(
     column_name,
     new_column_names: Union[str, Iterable[str], Any],
     sep: str,
-):
+) -> pd.DataFrame:
     """
     De-concatenates a single column into multiple columns.
 

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -242,7 +242,7 @@ def rename_kwargs(func_name: str, kwargs: Dict, aliases: Dict):
                     f"{func_name} received both {old_alias} and {new_alias}"
                 )
             warnings.warn(
-                "{old_alias} is deprecated; use {new_alias}",
+                f"{old_alias} is deprecated; use {new_alias}",
                 DeprecationWarning,
             )
             kwargs[new_alias] = kwargs.pop(old_alias)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ jupyter_client
 ipykernel
 seaborn
 pytest-azurepipelines
+pytest-cov

--- a/tests/biology/test_join_fasta.py
+++ b/tests/biology/test_join_fasta.py
@@ -15,7 +15,7 @@ def test_join_fasta(biodf):
     df = biodf.join_fasta(
         filename=os.path.join(pytest.TEST_DATA_DIR, "sequences.fasta"),
         id_col="sequence_accession",
-        col_name="sequence",
+        column_name="sequence",
     )
 
     assert "sequence" in df.columns

--- a/tests/functions/test_bin_numeric.py
+++ b/tests/functions/test_bin_numeric.py
@@ -8,7 +8,7 @@ from janitor.testing_utils.strategies import df_strategy
 @given(df=df_strategy())
 def test_bin_numeric_expected_columns(df):
 
-    df = df.bin_numeric(from_column="a", to_column="a_bin")
+    df = df.bin_numeric(from_column_name="a", to_column_name="a_bin")
     expected_columns = [
         "a",
         "Bell__Chart",
@@ -28,5 +28,8 @@ def test_bin_numeric_num_labels(df):
     with pytest.raises(ValueError):
         labels = ["a", "b", "c", "d", "e"]
         df.bin_numeric(
-            from_column="a", to_column="a_bin", num_bins=6, labels=labels
+            from_column_name="a",
+            to_column_name="a_bin",
+            num_bins=6,
+            labels=labels,
         )

--- a/tests/functions/test_groupby_agg.py
+++ b/tests/functions/test_groupby_agg.py
@@ -22,8 +22,8 @@ def test_groupby_agg():
 
     df_new = df.groupby_agg(
         by="date",
-        new_column="date_average",
-        agg_column="values",
+        new_column_name="date_average",
+        agg_column_name="values",
         agg=pd.np.mean,
     )
     assert df.shape[0] == df_new.shape[0]
@@ -51,8 +51,8 @@ def test_groupby_agg_multi():
 
     df_new = df.groupby_agg(
         by=["date", "user_id"],
-        new_column="date_average",
-        agg_column="values",
+        new_column_name="date_average",
+        agg_column_name="values",
         agg=pd.np.count_nonzero,
     )
 

--- a/tests/functions/test_impute.py
+++ b/tests/functions/test_impute.py
@@ -22,5 +22,5 @@ def test_impute_single_value(missingdata_df):
     ],
 )
 def test_impute_statistical(missingdata_df, statistic, expected):
-    df = missingdata_df.impute("a", statistic=statistic)
+    df = missingdata_df.impute("a", statistic_column_name=statistic)
     assert set(df["a"]) == expected


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request: 

- Fix f-string for argument deprecation warning (!!)
- Updated deprecated arguments in tests
- Add type hints to some function returns

<!-- Doing so provides maintainers with context on what the PR is, and can help us more effectively review your PR. -->

<!-- Please also identify below which issue that has been raised that you are going to close. -->

**This PR resolves #59 .**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [X] PR in from a fork off your branch. Do not PR from `<your_username>`:master, but rather from `<your_username>`:<branch_name>.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [X] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
<!-- We'd like to acknowledge your contributions! -->

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [ ] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - [X] black formatting
    - [X] pycodestyle checking
    - [X] running the test suite
    - docs build
    
Once done, please check off the check-box above.
    
If `make check` does not work for you, you can execute the commands listed in the Makefile individually.

## Code Changes

<!-- If you have not made code changes, please feel free to delete this section. -->

If you are adding code changes, please ensure the following:

- [ ] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [X] Check to ensure that test coverage covers the lines of code that you have added.
    - [X] Ensure that all tests pass.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
