### PR TITLE
[BUG] reset_index in intro notebook

### DIFF
--- a/examples/notebooks/pyjanitor_intro.ipynb
+++ b/examples/notebooks/pyjanitor_intro.ipynb
@@ -63,7 +63,7 @@
     "    .rename_column('column2', 'unicorns')\n",
     "    .rename_column('column3', 'dragons')\n",
     "    .add_column('new_column', ['iterable', 'of', 'items'])\n",
-    "    .reset_index(drop=True)\n",
+    "    .reset_index()\n",
     ")\n",
     "```\n",
     "\n",


### PR DESCRIPTION
This was a bug introduced because `reset_index_inplace()` was deprecated and removed, I'm guessing.

@ericmjl 