### PR TITLE
[ENH] Add Example Notebook for Finance Submodule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ v0.18.1 (on deck)
   h/t @jtaylor for sharing original
 - [ENH] add engineering submodule with unit conversion method by @rahosbach
 - [DOC] add PyPI project description
+- [ENH] add example notebook with use of finance submodule methods by @rahosbach
 
 For changes that happened prior to v0.18.1,
 please consult the closed PRs,

--- a/examples/notebooks/inflating_converting_currency.ipynb
+++ b/examples/notebooks/inflating_converting_currency.ipynb
@@ -1,0 +1,484 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inflating and Converting Currency"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Background"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook serves to show a brief and simple example of how to use the `convert_currency()` and `inflate_currency()` methods from pyjanitor's finance submodule.\n",
+    "\n",
+    "The data for this example notebook come from the [United States Department of Agriculture Economic Research Service](https://www.ers.usda.gov/data-products/food-expenditure-series/), and we are specifically going to download the data of nominal food and alcohol expenditures, with taxes and tips, for all purchasers.  The data set includes nominal expenditures for 1997-2018, and the expenditures are provided in U.S. dollars for the year in the which the expenditures were made.  For example, the expenditure values for 1997 are in units of 1997 U.S. dollars, whereas expenditures for 2018 are in 2018 U.S. dollars."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting and Cleaning the Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import janitor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>year</th>\n",
+       "      <th>store_type</th>\n",
+       "      <th>expenditure</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1997</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>270956.91</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1998</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>273638.88</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1999</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>283782.47</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2000</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>286669.78</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2001</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>296436.72</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   year      store_type  expenditure\n",
+       "0  1997  grocery_stores    270956.91\n",
+       "1  1998  grocery_stores    273638.88\n",
+       "2  1999  grocery_stores    283782.47\n",
+       "3  2000  grocery_stores    286669.78\n",
+       "4  2001  grocery_stores    296436.72"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "url = 'https://www.ers.usda.gov/webdocs/DataFiles/50606/nominal_expenditures.csv?v=9289.4'\n",
+    "# 1) Read in the data from .csv file\n",
+    "# 2) Clean up the column names\n",
+    "# 3) Remove any empty rows or columns\n",
+    "# 4) Melt the dataframe (from wide to long) to obtain \"tidy\" format\n",
+    "data = (\n",
+    "    pd.read_csv(url, skiprows=4, usecols=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], nrows=22, thousands=',')\n",
+    "    .clean_names()\n",
+    "    .remove_empty()\n",
+    "    .melt(id_vars=['year'], var_name='store_type', value_name='expenditure')\n",
+    "    )\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use inflate_currency() to Inflate All Values to 2018$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>year</th>\n",
+       "      <th>store_type</th>\n",
+       "      <th>expenditure</th>\n",
+       "      <th>expenditure_2018</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1997</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>270956.91</td>\n",
+       "      <td>423875.807122</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1998</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>273638.88</td>\n",
+       "      <td>421528.097543</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1999</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>283782.47</td>\n",
+       "      <td>427793.590858</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2000</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>286669.78</td>\n",
+       "      <td>418029.852893</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2001</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>296436.72</td>\n",
+       "      <td>420391.299188</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   year      store_type  expenditure  expenditure_2018\n",
+       "0  1997  grocery_stores    270956.91     423875.807122\n",
+       "1  1998  grocery_stores    273638.88     421528.097543\n",
+       "2  1999  grocery_stores    283782.47     427793.590858\n",
+       "3  2000  grocery_stores    286669.78     418029.852893\n",
+       "4  2001  grocery_stores    296436.72     420391.299188"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from janitor.finance import inflate_currency, convert_currency\n",
+    "\n",
+    "# Use split-apply-combine strategy to obtain 2018$ values\n",
+    "# Group the data frame by year\n",
+    "grouped=data.groupby(['year'])\n",
+    "# Apply the inflate_currency() method to each group\n",
+    "# (Note that each group comes with a name; in this case,\n",
+    "#  the name corresponds to the year)\n",
+    "data_constant_dollar = grouped.apply(lambda x: x.inflate_currency(\n",
+    "        column_name='expenditure',\n",
+    "        country='USA',\n",
+    "        currency_year=x.name,\n",
+    "        to_year=2018,\n",
+    "        make_new_column=True))\n",
+    "data_constant_dollar.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot Time Series to Observe Currency Inflation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x1e48363e198>"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZMAAAEGCAYAAACgt3iRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOzdd3gVVfrA8e9LEhJKQk1oAQLSuxKagiAqxYa6oqAgKoJ11113EcvPte+qu64dFQUBRVFssCwKiqIoCAQp0muA0EIqCenJ+/tjJnCBhCSk3JT38zz3uXPPnDlz7uTmvvfMOTNHVBVjjDGmOKp5uwLGGGMqPgsmxhhjis2CiTHGmGKzYGKMMabYLJgYY4wpNl9vV6CkNWzYUMPCwrxdDWOMqVDWrFkTo6rB57p9pQsmYWFhREREeLsaxhhToYjI3uJsb6e5jDHGFJsFE2OMMcVmwcQYY0yxVbo+k7xkZmYSFRVFWlqat6tiylBAQAChoaH4+fl5uyrGVHpVIphERUURGBhIWFgYIuLt6pgyoKrExsYSFRVFq1atvF0dYyq9KnGaKy0tjQYNGlggqUJEhAYNGlhr1JgyUiWCCWCBpAqyv7kxZadKnOYyxhiTj5Q4Vsx7p9jFVJmWiXEMGjToxEWdV1xxBQkJCSQkJDBlyhQv18wYU2ZysmHHt/DpOLL/3Y5+254vdpEWTKqwhQsXUrdu3XMOJtnZ2aVQK2NMqYnZCd89CS93htk3kLFzKbMyBvN/jd8qdtEWTMrQhx9+SO/evenRowd33XUXe/fupW3btsTExJCTk8OAAQNYvHgxkZGRdOjQgXHjxtGtWzduuOEGUlJSAFizZg0DBw6kZ8+eDB06lEOHDgFOi2Py5Mn07t2bdu3asWzZMgBSU1MZNWoU3bp146abbiI1NfVEfcLCwoiJieHhhx9m165d9OjRg0mTJrF06VKuuuqqE/nuv/9+ZsyYcWKbp59+mv79+zN37lx27drFsGHD6NmzJwMGDGDr1q1ldDSNMYWSdgzWzIRpQ+CNnvDLq9C4G1svfpPzj7/O/KYP8OgdNxZ7N1Wuz+Sp/25i88FjJVpmp6ZBPHF157Pm2bJlC5988gm//PILfn5+3Hvvvfz4449MnjyZu+++mz59+tCpUyeGDBlCZGQk27ZtY9q0aVx00UXccccdTJkyhQceeIA//vGPzJs3j+DgYD755BMee+wxpk+fDkBWVharVq1i4cKFPPXUU3z33Xe89dZb1KxZkw0bNrBhwwYuuOCCM+r2/PPPs3HjRtatWwfA0qVLz/peAgIC+PnnnwG49NJLefvtt2nbti0rV67k3nvv5fvvvz+Ho2iMKTE5ObD3Z1g7GzbPg6xUaNgOLnsKuo9i47EajJr6K00bBPD+bb2oWb34oaDKBRNvWbJkCWvWrKFXr16A02IICQnhySefZO7cubz99tsnvswBmjdvzkUXXQTAmDFjeO211xg2bBgbN27k8ssvB5zTTE2aNDmxzfXXXw9Az549iYyMBOCnn37iT3/6EwDdunWjW7duxX4vN910EwDJycksX76ckSNHnliXnp5e7PKNMecofi+s+wjWfwQJ+8A/CLqPgvPHQLOeIMLuo8mMm76COjX8mDW+N3VrVi+RXVe5YFJQC6K0qCrjxo3jn//85ynpKSkpREVFAc6Xc2BgIHDmsFYRQVXp3LkzK1asyHMf/v7+APj4+JCVlXXKtkXh6+tLTk7OidenX6tRq1YtAHJycqhbt+4pQdAYU8ZysmHzVxDxPkQuAwRaD4TBf4eOV4FfjRNZDyemMXbaKhT4YHxvmtSpkW+xRWV9JmXk0ksv5bPPPiM6OhqAuLg49u7dy+TJk7nlllt4+umnmTBhwon8+/btOxE0Pv74Y/r370/79u05evToifTMzEw2bdp01v1efPHFzJ49G4CNGzeyYcOGM/IEBgaSlJR04nXLli3ZvHkz6enpJCYmsmTJkjzLDgoKolWrVsydOxdwAub69esLe0iMMcWRnQXr58CbveGzOyBxP1zyGPz5d7h1HnQbeUogSUjJ4NbpK0lIyWDm7b1pHVy7RKtjwaSMdOrUiWeffZYhQ4bQrVs3Lr/8ciIjI1m9evWJgFK9enXef/99ADp27MjMmTPp1q0bcXFx3HPPPVSvXp3PPvuMyZMn0717d3r06MHy5cvPut977rmH5ORkunXrxosvvkjv3r3PyNOgQQMuuugiunTpwqRJk2jevDk33ngj3bp145ZbbuH888/Pt/zZs2czbdo0unfvTufOnZk3b17xDpQx5uyyM+G3D+CNcPjyLvANgBtnwR/XwsCHoG7zMzZJycjijhmriYxJ4d1bw+kaWqfEqyWqWriMIj5ABHBAVa8SkRnAQCDRzXKbqq4T55zKq8AVQIqb/ptbxjjg/9z8z6rqTDe9JzADqAEsBB5QVRWR+sAnQBgQCdyoqvFnq2d4eLiePjnWli1b6NixY6HeZ3kQGRnJVVddxcaNG71dlQqvov3tjclXVjqsmw0/v+z0hzTpDgMnQ7vhUC3/dkFmdg4TZkXw0/ajvHnzBQzv2iTPfCKyRlXDz7V6RWmZPABsOS1tkqr2cB+5J86HA23dx0TgLbei9YEngD5Ab+AJEannbvOWmzd3u2Fu+sPAElVtCyxxXxtjTNWRmQar3oXXzocFf4FaIXDzXJj4I3S48qyBJCdH+dvc9SzddpTnruuabyApCYUKJiISClwJvFeI7COAWer4FagrIk2AocC3qhrnti6+BYa564JUdYU6zaRZwLUeZc10l2d6pFdqYWFh1ioxpqrLSIEVU+DV7rDwb1CnOYz9Eu78DtoNgQIG1qgqTy/YzLx1B5k0tD2je7co1eoWdjTXK8BDQOBp6c+JyN9xWw2qmg40A/Z75Ily086WHpVHOkAjVT0EoKqHRCQkr8qJyESclg0tWpTuATPGmFKVngwR02H5a3D8KIQNgD+86zwXYWTmG9/vZMbySMb3b8W9g84rxQo7CgwmInIVEK2qa0RkkMeqR4DDQHVgKjAZeBrI693qOaQXmqpOdetAeHh4kbY1xphyIT3JOZ214g1IiYXWlzgd6i0vLHJRH/66l5e+3c715zfjsSs6lskdtAvTMrkIuEZErgACgCAR+VBVx7jr00XkfeBv7usowHM4QShw0E0fdFr6Ujc9NI/8AEdEpInbKmkCRBf2jRljTLmUmQrHDkJilPN8LAoS9jtXqqclQNshcPFD0LzXORX/vw2HeHzeRgZ3COGFG7pRrVrZTMVQYDBR1UdwWiG4LZO/qeoYjy95wenLyD3JPx+4X0Tm4HS2J7r5FgH/8Oh0HwI8oqpxIpIkIn2BlcCtwOseZY0DnnefbdypMab8ykp3A8QBSDzgPJ9YdoNHSuyZ29VsAGH9YcBfodmZtzwqrJ93xPDnT9YS3rIeb958AX4+ZXf1R3GugJ8tIsE4p6nWAXe76QtxhgXvxBkafDuAGzSeAVa7+Z5W1Th3+R5ODg3+2n2AE0Q+FZHxwD7g5H07jDGmPEiJg28fh+2L4XgeJ08C6kBQKNRpBs3Cnecg91EnFIKannJx4blavz+BiR9EcF5wbd4b14sa1X2KXWaRqGqlevTs2VNPt3nz5jPSqqqBAwfq6tWrVVV1+PDhGh8fr/Hx8frmm2+W+r5feukl7dixo3bt2lUHDx6skZGRJ9bNmDFD27Rpo23atNEZM2acSH/00Uc1NDRUa9WqdUpZe/fu1UGDBmmPHj20a9eu+r///S/Pfdrf3pSqrQtV/9VW9an6qp9PUP3hn6prZqnuXKIavU01LalMqrHjSJL2eGqR9n9hiR5JTD2nMoAILcZ3r9e//Ev6YcHk7DyDSa49e/Zo586di1xWVlZWkfJ///33evz4cVVVnTJlit54442qqhobG6utWrXS2NhYjYuL01atWmlcXJyqqq5YsUIPHjx4RjCZMGGCTpkyRVVVN23apC1btsxzn/a3N6UiJU7184mqTwSpTrlQ9eA6r1UlKj5F+/3jO+35zLe652jyOZdT3GBS5W70yNcPw+HfS7bMxl1heMEzlX344Ye89tprZGRk0KdPHx599FEuu+wyVqxYQf369Rk4cCCPP/447dq1Y9iwYfTp04e1a9fSrl07Zs2aRc2aNVmzZg0PPvggycnJNGzYkBkzZtCkSRMGDRpEnz59+OGHH0hISGDatGkMGDCA1NRUbr/9djZv3kzHjh3PmM8kIiLilPlMLr/8cq688kr+/e9/s2DBAsCZzyQ8PJzbbruNsLAw7rjjDhYvXsz9999Pr169uO+++zh69Cg1a9bk3XffpUOHDnm+/0suueTEct++ffnwww8BWLRoEZdffjn169cH4PLLL+ebb75h9OjR9O3bN8+yRIRjx5ypBBITE2natGkh/lDGlIBt38B/H3CG7V78EFw8CXxL5s67RRWTnM7Y91aSlJbFnLv6EtawllfqAVXwrsHeYvOZnGratGkMHz4cgAMHDtC8+ckBgKGhoRw4cOCs2z/55JMMGTKE119/nePHj/Pdd98VuE9jiiU1Hr55BNZ/DCGd4eZPoGkPr1XnWFom46av4mBiKh+M70PnpiV/v62iqHrBpBAtiNJg85mc9OGHHxIREcGPP/4IOKdaT1fQuPiPP/6Y2267jb/+9a+sWLGCsWPHsnHjRqqd5dYSxpyz7Yuc1khytNMSufghr7VGANIys7lzZgTbDifx7q3h9Aqr77W65Kp6wcRLVG0+E4DvvvuO5557jh9//PFEfUNDQ09pDUVFRTFo0KCzljNt2jS++eYbAPr160daWhoxMTGEhOR5kwRjzk1qgtsa+QhCOsHoj6Fp/nfRLguZ2TncN/s3VkfG8cpNPbikQ/n4zNvPuDJi85nA2rVrueuuu5g/f/4pX/pDhw5l8eLFxMfHEx8fz+LFixk6dOhZ31eLFi1O1GvLli2kpaURHBx81m2MKZLti2FKX9jwCQz4G0xc6vVAkpOjTJq7niVbo3l6RBdG9GhW8EZlxIJJGbH5TGDSpEkkJyczcuRIevTowTXXXANA/fr1efzxx+nVqxe9evXi73//+4nO+IceeojQ0FBSUlIIDQ3lySefBOCll17i3XffpXv37owePZoZM2aUyS0jTBWQmgBf3QsfjYSAus6NFS99HHz9vVotVeWp/27iK/fGjWP7tvRqfU5X6PlMKgqbz8R4qmh/e+NlO76F+X+C5CPQ/8/OfCFeDiK5/vPtdl5bsoMJA1rxaCncb6u485lYn4kxxqQlwjePwroPIbgjjJpdrNualLRpP+/htSU7uDE8tFQCSUmwYFIOVfT5TJ577rkT/Si5Ro4cyWOPPealGhlzFoc3wie3OLMX9n8QBj1cblojAJ+vieKZBZsZ1rkx/7iua7kMJFCFgomqlts/QmXz2GOPlYvAUdlO4ZpSsGEuzP8j1KgLt38DLfp4u0anWLzpMA99voGL2jTg1dE98C3DGzcWVfmtWQkKCAggNjbWvlyqEFUlNjaWgIAAb1fFlEfZmc6Q3y/udEZoTfyx3AWS5btiuP/jtXRtVoepY8Px9y3jGzcWUZVomYSGhhIVFcXRo0e9XRVThgICAggNDS04o6lakqNh7m2w9xfocw8MeQZ8/Lxdq1NsiEpgwswIwhrU5P3belHLv/x/VZf/GpYAPz8/WrVq5e1qGGO8bf9q+HSsM/z3uqnQ/SZv1+gMO6OTGDd9FfVqVeeD8X2oV8t7V9oXRZUIJsaYKk4V1rwPCx9y5g8ZvxiaFP/WQiUtKj6FMe+twtenGrPv7EOjoIpzmtaCiTGmcstMg4V/g7UfQJvL4Pp3oab372V1uqNJ6YydtoqUjCw+uasfLRt47w7A58KCSUnIyYFdS5wPa61guOSxcvlhNabKSdjvnNY6uNa5QeOgR6Ba+evITkx17gB8KDGV2Xf2oWOTIG9XqcgKHUxExAeIAA6o6lUiMhsIBzKBVcBdqprpzhM/D9jjbvqFqj7tljEMeBXwAd5T1efd9FbAHKA+8BswVlUzRMQfmAX0BGKBm1Q1snhvuQQdj3ECSMT7kLAXajaEtATYPA+GvwidrwMbjmyMd+z5yeloz8qAUR9Bhyu9XaMzpGVm89XaA7zz026i4lN4b1wverasmD9EizI0+AFgi8fr2UAHoCvO3O13eqxbpqo93EduIPEB3gSGA52A0SLSyc3/AvCyqrYF4oHxbvp4IF5V2wAvu/m8SxX2/QqfT4D/dITvnoQ6zeGG6fDgFudmcHVC4bPb4ePRkBjl5QobU8Wowi+vwawRzg+8iT+Uu0ASfzyDN77fQf8XfuDhL36nZnUfpo3rxcB2FfdmpYVqmYhIKHAl8BzwIICqLvRYvwooaAxmb2Cnqu52t5kDjBCRLcBg4GY330zgSeAtYIS7DPAZ8IaIiHrjgpH0JOfuoaunQ/Qm8A+CnrdD+B0Q4jGzYOOucOcSWPk2fP8svNkXLnsCwseDzbVhTOlKT4b598OmL6HjNXDtFPAP9HatTtgfl8J7y3bzaUQUqZnZDGwXzF0Xt6bfeQ0q/EXVhT3N9QrwEHDGX0VE/ICxOC2XXP1EZD1wEPibqm4CmgH7PfJEAX2ABkCCqmZ5pOfeV/nENqqaJSKJbv6Y0+owEZgI0KVZLVjyNDRsBw3aQsM2EFCMGciObILV05xAkpEMjbvB1a9C15FQPZ8Osmo+0O8+59fQgr84nX+/z4WrXzs18BhjSk7sLphzC8Rsg8uegoseKDenmdfvT2Dqst18/fshfKoJ13RvxoSLW9GhccXrG8lPgcFERK4ColV1jdsfcropwE+qusx9/RvQUlWTReQK4CugLZDXX1XPkk4B604mqE4FpgKEt6il/PwKaPbJDLUbucGljfPcsK2zXLdF3p1xWelOv8fqabD/V/ANgM7XQ6/x0Kxn4T+g9cJgzBdOIPrmYXhnAAz4K/T/S7m6948xFUp6snNX36RDkHTYfRyC3z5w/p/HfAHnXeLtWpKTo/ywLZqpP+1m5Z44Av19mXBxa26/sBWN61ScIb+FVZiWyUXANW5gCACCRORDVR0jIk8AwcBduZlV9ZjH8kIRmSIiDXFaHM09yg3FabnEAHVFxNdtneSm47FNlIj4AnWAuLPWNqQj/N8KiI+EmO0Qs8N5xO6AzV858zjn8vGHBue5waWt8xy9xelUT4mF+q1hyLPQ45ZzH50lAt1HwXmXwqJHYOk/nSb4Na9D8zPnFjGmSlJ1Wv5JRyD58KlBIumwR/A4AhlJZ27vGwDNwp3TWvW8O89HepbTqf7usj3sjE6maZ0A/u/KjtzUqzmBAeXrSvuSVKT5TNyWyd/c0Vx3AncAl6pqqkeexsARVVUR6Y3T19ESZwTXduBS4ACwGrhZVTeJyFzgc1WdIyJvAxtUdYqI3Ad0VdW7RWQUcL2q3ni2OuY1n8kpjsc6geX0QBO3x2nNiA+0H+60QloNKvl+jh3fOqe+EqOg9wS49O8ld043M9X5pyonTfsqJzkaqteG6jW9XZOylZHiDI0/sMa5piMrzWndez5nZ7iv81iX5a4786SD83kObAy1GzvPuY/TXwfU9frnPjElkw9X7mXG8kiOJqXTqUkQEy9uzZXdmuBXjm/QmKu485kUJ5hkAXuB3J8JX6jq0yJyP3APkAWkAg+q6nJ3+ytw+l98gOmq+pyb3pqTQ4PXAmNUNV1EAoAPgPNxWiSjcjvw81NgMMlPVobTmgmoA4GNir59UaQnO53zK992rsa98j/QfljhtlWFYwdOBsKY7W5w3OGkN+oCQ5+D1oNK8x2YXBnHYePnzvDwg785aQF1ILCJ+0XX1H1uAkFNTqbXblTu7gdVJKkJsH0RbP0v7PgOslKhmi/41XJO4foGgG9199n/1GefvNL9nT7IwCbOsck9TgF1vB4kCpKWmc3r3+/g/V8iScnI5uJ2wUwc0JqL2lSsTvUyDSYVwTkHE2+IinBufx292emTGf4C1HbnRs9MhdideQSNnZB5/GQZ1QOd03MN20Hd5k7/TMI+aDfcOUXXsI133ltld3ijc3uODZ9C+jEI7gDdbgLUOS1z7ODJUzXJhyEn67QCxLnANbCx84Mi99d2jXrOF2hAHee26AF1nF/dAXWcL1tvfjklR8PW/8GW/8KeH533FNgEOlwFHa+GlheBT9W6Dvq3ffFMmrueXUePc033ptwz6LwKecEhWDA5Q4UKJuC0iH55FX56EfxqOh38sTucK3c9xyHUaX4yaDTMHUjQzvkV5/kFk5kGv06BZf9xfi32mgADH7Ir8ktCZqrT3xXxPkStcvrcOl/rDBFv0Tf/L/qcHEiJcc75Hzvk0XF88NR+geMF3NW6mu/JQJMbYDwDTo16zg+KumFOv0HNBsUPPvF7YesCJ4Ds+xVQpy+x49XQ4Wrn81oFh7ynZWbzn2+3896y3TQOCuCff+hWoa8RAQsmZ6hwwSTX0e1OB31y9MlAkRs06p9X9PPwydHww3Pw2yzny2bgw04/UEU+teIt0VudVsj6j53pXRu0cQJIj5tLNkhnZzmtnNR4Zz9pic4dFdISndNKeb5201ITICfz1PL8ajkjFuu1hLot3ecWJ5fzGjKvCke3OcFj63/h0HonvVFXJ4B0vApCOpX7U0+lac3eOCbN3cDumOOM7t2CR6/oUCk61i2YnKbCBpPScngjLH4Mdi91RqwNeRbaDa3SXwaFkpkGW+Y7rZB9y6GaH3S6xgkiYf3L3/FTdS6sTdjnPvY6rQrP5dNHQQXUPTXASDXY9rXTMgZo3sc9hXWV0xqp4lIzsvn34m1M/2UPTevU4IU/dKN/24berlaJsWByGgsmeVB1OksXP+b0w7QeBEP/AY06e7tmxZOT4ww6yO1Lio90ztn7Bzp3KPAPcpcDPdLcZb8aeQeEmJ1OK2TdR5AaB/VaQc/bnOHhtSvwaQxVp8VzIsicFmwS9jmzD7Ya4LRA2l/pDBgwAKzaE8dDn60nMjaFsX1bMnl4B2pXgAmrisKCyWksmJxFdqZzIebSfzqnUy641bnDcW6nf3mVnuQORth5cuRazA6I2wWZKSfz+dYAzYHs9ILLFJ8zA0xOpjO8tZqvc/eCnrdDq4FVo08gJ8cZvutX+S6mK46UjCxe/GYbM1dEElrPaY1ceF7laY14smByGgsmhZASBz++CKvfdb6AL/6rM32pN79Icq9qjtt98tqfmB1OEEk6dDKfVHNOy+ReZNqgzcmLTgMbO62NrHSnvPRjTiA65XGWtKx0aHs5nD+29IeHm3Jvxa5YJn++gX1xKdx2YRiThravENPnnisLJqexYFIEMTtg8eOw/WvnC/qyp5z+FJ/qzq/z4vQL5F7RnBztjFJKjnaCRe7yiedo59mzhQHO+fwTdyZoczJ41G9tt6Ixpep4ehbPf72VD37dS8sGNXnxD93o07qBt6tV6oobTCpvmDUFa9gWbp4Du36ARY85t833VM3PCSw+fu7DXc4rvZqvs5yW6AaOaGdo8hnEGbJaO8S5ziK0lzO8uVawk1avlVOvkhjWakwR/bIzhsmfb+BAQip3XNSKSUPbU6N6+ZtMqzyyYGKcm+Ldvcy5d1nCfqfvIDvTOYee7bGcb3qWczuM9CQICHJGAdUOcQNGiNNxXSvECRo1G1S5C9tM+ZecnsU/Fm7ho5X7aNWwFnPv6kd4mF2bVRT2X20c1Xygyx+8XQtjylxqRja3vPsrGw4kMmFAK/46pD0BftYaKSoLJsaYKis7R/nzJ2vZcCCRt8f0ZGjnxt6uUoVVBcY8GmNM3p7/eguLNh3h8Ss7WSApJgsmxpgq6YNf9/Lusj2M69eS2y8K83Z1KjwLJsaYKueHbdE8MW8jgzuE8PhVnSrUreLLKwsmxpgqZfPBY9w/+zc6Ngni9dHn41sBJq6qCOwoGmOqjMOJadwxYzWBAX5MG9erUl/RXtYsmBhjqoTj6VmMn7mapLRMpt/Wi8Z17D5kJanQwUREfERkrYgscF+3EpGVIrJDRD4Rkepuur/7eqe7PsyjjEfc9G0iMtQjfZibtlNEHvZIz3MfxhhTFNk5yp8+XsuWQ8d44+YL6NS0Ys6GWJ4VpWXyALDF4/ULwMuq2haIB8a76eOBeFVtA7zs5kNEOgGjgM7AMGCKG6B8gDeB4UAnYLSb92z7MMaYQntmwWaWbI3mqRFduKRDOb9LdgVVqGAiIqHAlcB77msBBgOfuVlmAte6yyPc17jrL3XzjwDmqGq6qu4BdgK93cdOVd2tqhnAHGBEAfswxphCef+XPcxYHsmd/Vsxtm9Lb1en0ipsy+QV4CEgx33dAEhQ1Sz3dRTQzF1uBuwHcNcnuvlPpJ+2TX7pZ9vHKURkoohEiEjE0aMFzKNtjKkyvt18hKcXbGZo50Y8ckVHb1enUiswmIjIVUC0qq7xTM4jqxawrqTSz0xUnaqq4aoaHhxcgWfDM8aUmN+jEvnTx2vp1qwOr9x0Pj7V7FqS0lSYcXEXAdeIyBVAABCE01KpKyK+bsshFDjo5o8CmgNRIuIL1AHiPNJzeW6TV3rMWfZhjDH5OpCQyh0zV1O/VnXeHRdut5EvAwW2TFT1EVUNVdUwnA7071X1FuAH4AY32zhgnrs8332Nu/57dWbgmg+Mckd7tQLaAquA1UBbd+RWdXcf891t8tuHMcbkKSktk/EzVpOWkc3023oREmhDgMtCca4zmQw8KCI7cfo3prnp04AGbvqDwMMAqroJ+BTYDHwD3Keq2W6r435gEc5osU/dvGfbhzHGnCErO4f7PlrLzuhkpoy5gPaNA71dpSrDpu01xlQKqspjX23ko5X7eP76rozq3cLbVapQijttr10Bb4ypFN5dtpuPVu7jnkHnWSDxArsxjTGmQkvJyOLDX/fyz6+3cmW3Jkwa0t7bVaqSLJgYYyqkuOMZzFweyawVkcSnZDKwXTAvjexONRsC7BUWTIwxFcr+uBTeW7abTyL2k5aZw2UdQ7h74HmEh9X3dtWqNAsmxpgKYdPBRN75cTf/+/0Q1QRG9GjGXRe3pm0jG7FVHlgwMcaUW6rKil2xvPXjLpbtiKFWdR/uuCiMO/q3okmdGt6unvFgwRY734AAACAASURBVMQYU+5k5yhfbzzEOz/u5vcDiTSs7c9Dw9pzS5+W1Knh5+3qmTxYMDHGlBtpmdnMXRPFuz/tZl9cCq0a1uKf13fluvObEeBnt0QpzyyYGGO8LjE1k1nLI5mxPJLY4xl0b16XR6/owOWdGtsNGisICybGGK9Jy8xm1opI3vxhF4mpmQxqH8zdA8+jT6v6OFMamYrCgokxpsxl5yhf/BbFy99u52BiGgPbBTNpaHu6NKvj7aqZc2TBxBhTZlSVH7ZF88LX29h2JIluoXX498juXNimoberZorJgokxpkz8ti+e57/eyqo9cYQ1qMmbN1/AFV0b2+msSsKCiTGmVO06msy/vtnGN5sO07C2P89c24VRvZrj52P3ma1MLJgYY0rFkWNpvPLdDj6N2E+AbzX+clk77hzQilr+9rVTGdlf1RhToo6lZfLOj7uY9vMesnOUsX1bcv/gNjSs7e/tqplSZMHEGFMi0rOy+fDXfbzx/Q7iUzK5pntT/jqkHS0b1PJ21UwZKDCYiEgA8BPg7+b/TFWfEJFlQO4d1kKAVap6rYgMwpmrfY+77gtVfdotaxjwKuADvKeqz7vprYA5QH3gN2CsqmaIiD8wC+gJxAI3qWpksd+1MaZErdwdy4OfrudAQir92zTk4eEdbJhvFVOYlkk6MFhVk0XED/hZRL5W1QG5GUTkc5wAkmuZql7lWYiI+ABvApcDUcBqEZmvqpuBF4CXVXWOiLwNjAfecp/jVbWNiIxy8910zu/WGFPiIiLjuH3GahoFBfDB+N4MaBvs7SoZLyhwOIU6kt2Xfu7jxMTxIhIIDAa+KqCo3sBOVd2tqhk4LZER4owLHAx85uabCVzrLo9wX+Ouv1RsHKEx5cb6/Qnc/v5qGgcF8MldfS2QVGGFGpsnIj4isg6IBr5V1ZUeq68DlqjqMY+0fiKyXkS+FpHOblozYL9Hnig3rQGQoKpZp6Wfso27PtHNf3r9JopIhIhEHD16tDBvyRhTTJsPHuPW6auoW8uP2RP6EBIY4O0qGS8qVDBR1WxV7QGEAr1FpIvH6tHAxx6vfwNaqmp34HVOtljyalHoWdLPts3p9ZuqquGqGh4cbL+MjCltO44kMWbaSmpV9+GjO/va3CKmcMEkl6omAEuBYQAi0gDn9NX/PPIcyz0tpqoLAT8RaYjT4mjuUVwocBCIAeqKiO9p6Xhu466vA8QVpc7GmJK1+2gyN7+3Et9qwuwJfWlev6a3q2TKgQKDiYgEi0hdd7kGcBmw1V09Eligqmke+Rvn9muISG93H7HAaqCtiLQSkerAKGC+qirwA3CDW8Q4Tnbmz3df467/3s1vjPGC/XEp3PLeSnJylNl39qFVQxv2axyFGc3VBJjpjsaqBnyqqgvcdaOA50/LfwNwj4hkAanAKDcAZInI/cAinKHB01V1k7vNZGCOiDwLrAWmuenTgA9EZCdOi2TUubxJY0zxHUxIZfS7v5Kamc3HE/ra3OvmFFLZfuiHh4drRESEt6thTKUSfSyNG99ZQWxyBh9N6EvXULuGpLIRkTWqGn6u29sV8MaYs4pJTufm91YSnZTOB+P7WCAxebLbdhpj8pWQksGY91YSFZ/C9Nt60bNlPW9XyZRT1jIxxuTpWFomt05fxe6Y40wbF07f1mdc4mXMCdYyMcac4Xh6Fre/v5oth47x1i0X2JXtpkDWMjHGnCI1I5vxM1ezbn8Cb958Ppd2bOTtKpkKwFomxpgT0jKzmfhBBCv3xPGfG7szrEsTb1fJVBAWTIwxAGRk5XDf7N9YtiOGF//QjRE9mhW8kTEuCybGGNIys3lgzlqWbI3mueu6MDK8ecEbGePB+kyMqYJUlR3Ryfy0/SjLdsSwck8saZk5/P2qTtzSp6W3q2cqIAsmxpQT2TmKT7XSm64nJjmdX3bG8NP2GH7eeZQjx9IBaBNSm1G9WjCkUyMubNOw1PZvKjcLJsZ4WXaO8sp323lr6S7q1vSjZYNatKxf03luUNN91KJeTT+KMjdcelY2ayLj+WlHDMt2HGXTQWfKobo1/ejfpiEXtw2mf9uGNK1rt483xWfBxBgvSkjJ4IE56/hx+1GGd2lMUIAfe+OOs2J3LF+sPXBK3sAA3xOBpWX9moQ1qEWLBs5zSKA/IuR56srPR+jZsh6ThrZnQNuGdG5ap1RbQKZqsmBijJdsPJDIPbPXcDgxjeeu68LNvVuc0vJIy8wmKj6FyJgU9salsDf2OHtjU9h0IJFFGw+TlXPyJq3+vtWo5e9L3PEMAM4LrsWoXi24uF1D+rRqQC1/+1c3pcs+YcZ4wedronj0y9+pV7M6n97Vj/NbnHnPqwA/H9qEBNIm5MxbvWdl53AwIY29cU6A2Rt7nISUTMLD6tG/bTDN7NSVKWMWTIwpQxlZOTyzYDMf/LqXvq3r8/roCwgO9C9yOb4+1WjRoCYtGtRkQNtSqKgxRWTBxJgycjgxjXtnr+G3fQlMGNCKycM64Otjl3qZysGCiTFlYOXuWO77aC0pGVm8cfP5XNWtqberZEyJKswc8AEiskpE1ovIJhF5yk2fISJ7RGSd++jhpouIvCYiO0Vkg4hc4FHWOBHZ4T7GeaT3FJHf3W1e85hDvr6IfOvm/1ZEbDIFU6GoKtN+3sPN760kMMCXr+67yAKJqZQK08ZOBwaranegBzBMRPq66yapag/3sc5NGw60dR8TgbfACQzAE0AfoDfwhEdweMvNm7vdMDf9YWCJqrYFlrivjakQUjKy+NOcdTyzYDODO4Qw7/6LaGfzpptKqsBgoo5k96Wf+zjbxPEjgFnudr8CdUWkCTAU+FZV41Q1HvgWJzA1AYJUdYU6E9LPAq71KGumuzzTI92Ycm1PzHGue3M5CzYcZNLQ9rwzpidBAX7erpYxpaZQvX8i4iMi64BonICw0l31nHsq62URyR2S0gzY77F5lJt2tvSoPNIBGqnqIQD3OSSf+k0UkQgRiTh69Ghh3pIxpea7zUe45o2fOZKUxozbe3PfJW2oZhcJmkquUMFEVbNVtQcQCvQWkS7AI0AHoBdQH5jsZs/rv0bPIb3QVHWqqoaranhwsM0IZ7wjO0d5afE27pwVQYv6Nfnv/f0Z2M4+j6ZqKNK4RFVNAJYCw1T1kHsqKx14H6cfBJyWhef9q0OBgwWkh+aRDnDEPQ2G+xxdlPoaU1aOpWVyx4zVvP79Tm7oGcrn91xI8/o1vV0tY8pMYUZzBYtIXXe5BnAZsNXjS15w+jI2upvMB251R3X1BRLdU1SLgCEiUs/teB8CLHLXJYlIX7esW4F5HmXljvoa55FuTLkRfzyDMe+t5JedMTx7bRf+dUM3Avx8vF0tY8pUYa4zaQLMFBEfnODzqaouEJHvRSQY5zTVOuBuN/9C4ApgJ5AC3A6gqnEi8gyw2s33tKrGucv3ADOAGsDX7gPgeeBTERkP7ANGnusbNaY0RCelMfa9VeyJPc47Y3vafOmmyhJnAFXlER4erhEREd6uhqkCDiakMua9lRxKTOPdW8Pp39bmAjEVl4isUdXwc93eroA35hzsjT3Oze+u5FhqJrPG96ZXWH1vV8kYr7JgYkwR7YxO4pb3VpKelcPsCX3oFlrX21UyxussmBhTBJsOJnLrtFWICHMm9qVD4yBvV8mYcsFuWWpMIa3dF8/oqb9S3bcan95lgcQYT9YyMaYQft0dy/gZq2lQ25/Zd/axa0iMOY0FE2MKsHRbNHd9sIbm9Wsy+84+NAoK8HaVjCl3LJgYcxbfbDzMHz/+jbYhgXwwvjcNahd9VkRjqgILJsbkY966Azz46Xq6NqvDzNt7U6em3fXXmPxYMDEmD3NW7eORL3+nd1h9pt3Wi9r+9q9izNnYf4gxp5n+8x6eXrCZge2CeXtMT2pUt/tsGVMQCybGeHjzh538a9E2hnZuxGujz8ff1wKJMYVhwcQYnLna/7VoG1OW7uLaHk3598ju+PrYZVjGFJYFE1Pl7T6azCNf/M7KPXGM7t2cZ6/tio/NjGhMkVgwMVVWZnYOU3/azatLduDvW41/Xt+VUb2a40yrY4wpCgsmpkpatz+Bhz/fwNbDSQzv0pinrulMiF2MaMw5s2BiqpTj6Vm8tHg7M5bvITjQn3fG9mRo58berpYxFZ4FE1NlLN0WzWNfbuRAQipj+rbgoWEdCAqwCxGNKQmFmQM+QERWich6EdkkIk+56bNFZJuIbBSR6SLi56YPEpFEEVnnPv7uUdYwd5udIvKwR3orEVkpIjtE5BMRqe6m+7uvd7rrw0r6AJjKLzY5nT/PWctt768mwK8ac+/ux7PXdrVAYkwJKszYx3RgsKp2B3oAw0SkLzAb6AB0xZm7/U6PbZapag/38TSAO4f8m8BwoBMwWkQ6uflfAF5W1bZAPDDeTR8PxKtqG+BlN58xhaKqfPFbFJf950f+9/sh/nRpWxY+MMBmRTSmFBQYTNSR7L70cx+qqgvddQqsAkILKKo3sFNVd6tqBjAHGCHO0JnBwGduvpnAte7yCPc17vpLxYbamELYH5fCrdNX8eCn6wlrWIv//WkAD17ezi5CNKaUFKrPxG1VrAHaAG+q6kqPdX7AWOABj036ich64CDwN1XdBDQD9nvkiQL6AA2ABFXN8khv5i6f2EZVs0Qk0c0fc1r9JgITAVq0aFGYt2QqqazsHGYsj+SlxdupJvDUNZ0Z07elXTdiTCkrVDBR1Wygh4jUBb4UkS6qutFdPQX4SVWXua9/A1qqarKIXAF8BbQF8vpv1rOkU8A6z/pNBaYChIeHn7HeVA2bDx7j4S82sCEqkUs7hPDMtV1oWreGt6tlTJVQpNFcqpogIkuBYcBGEXkCCAbu8shzzGN5oYhMEZGGOC2O5h7FheK0XGKAuiLi67ZOctPx2CZKRHyBOkBc0d6iqexUlQ9X7uOp+ZuoW9OP10efz1XdmtjFh8aUocKM5gp2WySISA3gMmCriNwJDAVGq2qOR/7Guf0aItLb3UcssBpo647cqg6MAua7fS4/ADe4RYwD5rnL893XuOu/d/MbA0B6VjaPfvk7j3+1kQFtG/LdgwO5untTCyTGlLHCtEyaADPdfpNqwKequkBEsoC9wAr3H/cLd+TWDcA97vpUYJQbALJE5H5gEeADTHf7UgAmA3NE5FlgLTDNTZ8GfCAiO3FaJKOK/5ZNZRGdlMY9H/7Gmr3x3HfJeTx4eXvrGzHGS6Sy/dAPDw/XiIgIb1fDlLL1+xO464M1JKZm8q+R3biqW1NvV8mYCk1E1qhq+Llub1fAmwrn8zVRPPLl7wTX9ufzey6kU9Mgb1fJmCrPgompMLKyc/jn11uZ9vMe+rVuwJu3XED9WtW9XS1jDBZMTAURfzyD+z/+jV92xnLbhWE8dmVH/GzyKmPKDQsmptzbevgYE2ZFcCQxnRdv6MaN4c0L3sgYU6YsmJhy7ZuNh3jw0/XU9vdlzl19uaBFPW9XyRiTBwsmplzKyVFe+W47r32/kx7N6/LO2J40ssmrjCm3LJiYcicpLZO/fLKe77YcYWTPUJ65tgsBfnaDRmPKMwsmplzZE3OcCbMi2BNznCev7sS4C8PsanZjKgALJqbcWLotmj99vBafasIH43tz4XkNvV0lY0whWTAxXheTnM4LX29l7pooOjQO5N1bw2lev6a3q2WMKQILJsZrsrJzmL1yHy8t3kZKRjZ3DWzNA5e2pWZ1+1gaU9HYf63xitWRcfx93ia2HDpG/zYNefKazrQJqe3tahljzpEFE1OmopPSeH7hVr5Ye4CmdQKYcssFDO/S2DrZjangLJiYMpGVncPMFXt55dvtpGVlc++g87h/cBs7pWVMJWH/yabU/bo7lifmbWLbkSQubhfMk1d3onWwndIypjKxYGJKzZFjafxj4RbmrTtIs7o1eGdsT4Z0amSntIyphCyYmBKXmZ3DjF8ieeW77WTmKH8a3IZ7BrWhRnW7it2Yyqowc8AHiMgqEVkvIptE5Ck3vZWIrBSRHSLyiTuvOyLi777e6a4P8yjrETd9m4gM9Ugf5qbtFJGHPdLz3Icpv5bvjGH4q8t4buEW+rRuwOI/X8yDQ9pbIDGmkivMhBDpwGBV7Q70AIaJSF/gBeBlVW0LxAPj3fzjgXhVbQO87OZDRDrhzOHeGRgGTBERH3du+TeB4UAnYLSbl7Psw5QjqsraffHc8+Eabn5vJelZ2bx3azjTb+tFWMNa3q6eMaYMFHiaS51J4pPdl37uQ4HBwM1u+kzgSeAtYIS7DPAZ8IY4J8lHAHNUNR3YIyI7gd5uvp2quhtAROYAI0Rky1n2YcqBtMxsFmw4xKwVkWyISqS2vy9/vqwtdw88z27MaEwVU6g+E7f1sAZog9OK2AUkqGqWmyUKaOYuNwP2A6hqlogkAg3c9F89ivXcZv9p6X3cbfLbh/GiAwmpzP51L3NW7yfueAZtQmrzzIjOXHdBKLX9rRvOmKqoUP/5qpoN9BCRusCXQMe8srnPeQ3V0bOk53Wq7Wz5zyAiE4GJAC1atMgriykmVWXF7lhmLd/L4s2HAbisYyPGXRjGhec1sBFaxlRxRfoZqaoJIrIU6AvUFRFft+UQChx0s0UBzYEoEfEF6gBxHum5PLfJKz3mLPs4vV5TgakA4eHheQYcc26Op2fx5doDzFoRyfYjydSr6cfEi89jTN8WhNazmzEaYxwFBhMRCQYy3UBSA7gMp2P8B+AGYA4wDpjnbjLffb3CXf+9qqqIzAc+EpH/AE2BtsAqnBZIWxFpBRzA6aS/2d0mv32Y0+TkKF9vPEzs8XRCAv0JDvQnJDCA4ED/c+q/2BNznFkrIvksIoqk9Cy6NAviXzd04+ruTa0/xBhzhsK0TJoAM91+k2rAp6q6QEQ2A3NE5FlgLTDNzT8N+MDtYI/DCQ6o6iYR+RTYDGQB97mnzxCR+4FFgA8wXVU3uWVNzmcfxsPuo8k88sXvrNwTl+f6oABfQoICCAn0dx7ucm7ACQly0mtV92Xp9mhmLt/Lj9uP4ucjXNG1Cbf2C+OCFnXtVJYxJl/iDNaqPMLDwzUiIsLb1SgTmdk5TP1pN68u2UGAbzUeu7Ijl3QIIfpYOkeTnEd0UhrRSelEH/NYTkonIyvnjPL8fITMbCUk0J9b+rRkdJ/mhATavOvGVAUiskZVw891ext6U0Gt35/A5M83sPVwEld2bcIT13Q68cVfUABQVY6lZnkElzSij6UTezyDrs3qMKxLY/x8CnMJkjHGOCyYVDApGVm8tHg77/+yh+BAf6aO7cmQzo2LVIaIUKemH3Vq+tG2UWAp1dQYU5VYMKlAftx+lMe+/J2o+FTG9G3BQ8M6EBTg5+1qGWOMBZOKIO54Bs8u2MwXaw/QOrgWc+/uR6+w+t6uljHGnGDBpBxTVeavP8hT/93MsdRM/jS4Dfde0saG5hpjyh0LJuVUVHwK//fVRpZuO0qP5nV5/g9d6dA4yNvVMsaYPFkwKWeyc5RZKyL516JtADxxdSdu7ReGTzW7xsMYU35ZMCkn0jKz+f1AIs/9bwvr9icwqH0wz17bxW5ZYoypECyYeEFCSgabDx1j80HnsengMXYeTSY7R6lfqzqvjurBNd2b2hXnxpgKw4JJKVJVDiSknggYuQHkQELqiTyNgwLo1DSIyzs1onPTIC48ryF1atpwX2NMxWLBpAQdTkxj+a6YU4JHYmomACLQumEtLmhZj7H9WtK5aRAdmwTRsLa/l2ttjDHFZ8GkBOS4neYvfLON1Mxs/H2r0aFxIFd0bUKnpkF0bhpEh8aB1Kxuh9sYUznZt1sx7Y09zqTPNrBqTxyD2gfz0NAOtGtUG1+7t5UxpgqxYHKOcnKUmSsiefGbbfj6CC/e0I2RPUOt09wYUyVZMDkHkTHHeeizDayKjOOS9sH84/quNKlTw9vVMsYYr7FgUgQ5OcqM5ZG8uGgrfj7V+PfI7vzhgmbWGjHGVHkWTAopMuY4kz5bz+rIeAZ3COEf13WlcR2bOMoYY8CCSYFycpT3l0fyL2uNGGNMvgocciQizUXkBxHZIiKbROQBN/0TEVnnPiJFZJ2bHiYiqR7r3vYoq6eI/C4iO0XkNXG/kUWkvoh8KyI73Od6brq4+XaKyAYRuaB0DkPe9sQc56apK3hmwWYuPK8h3/5lIDdYJ7sxxpyhMC2TLOCvqvqbiAQCa0TkW1W9KTeDiLwEJHpss0tVe+RR1lvAROBXYCEwDPgaeBhYoqrPi8jD7uvJwHCgrfvo427fp4jvsciyc5T3f9nDvxZtw9+3Gv+5sTvXnW+tEWOMyU+BwURVDwGH3OUkEdkCNAM2g9N6AG4EBp+tHBFpAgSp6gr39SzgWpxgMgIY5GadCSzFCSYjgFmqqsCvIlJXRJq4dSoVu48mM+mzDazZG8+lHUL4x/VdaRRkfSPGGHM2ReozEZEw4HxgpUfyAOCIqu7wSGslImuBY8D/qeoynAAU5ZEnyk0DaJQbIFT1kIiEuOnNgP15bHNKMBGRiTgtHlq0aFGUt0RKRhbbjySz/XASmw4mMmf1fmuNGGNMERU6mIhIbeBz4M+qesxj1WjgY4/Xh4AWqhorIj2Br0SkM5DXt7IWtNvCbKOqU4GpAOHh4XmWmZ2jRMYeZ+uhJLYdPsbWw0lsO5LEvrgU1N2ihp8Pl3YM4cmrOxNirRFjjCm0QgUTEfHDCSSzVfULj3Rf4HqgZ26aqqYD6e7yGhHZBbTDaVWEehQbChx0l4/knr5yT4dFu+lRQPN8tsnXkWNpTrDIDRqHk9gZnUx6Vg4A1QTCGtaic9Mgrj8/lPaNA+nQOJAW9WtSzSahMsaYIiswmLh9ItOALar6n9NWXwZsVdUoj/zBQJyqZotIa5zO892qGiciSSLSF+c02a3A6+5m84FxwPPu8zyP9PtFZA5Ox3tiQf0lmw8do88/lpx4HRLoT/vGgdzaryXtGzs3XGwTUtvmUTfGmBJUmJbJRcBY4Pfc4b/Ao6q6EBjFqae4AC4GnhaRLCAbuFtV49x19wAzgBo4He9fu+nPA5+KyHhgHzDSTV8IXAHsBFKA2wuqbJ0afjx5dSfaNw6ifeNA6teqXoi3aIwxpjhEtaBui4olPDxcIyIivF0NY4ypUERkjaqGn+v2dp90Y4wxxWbBxBhjTLFZMDHGGFNsFkyMMcYUmwUTY4wxxWbBxBhjTLFZMDHGGFNsFkyMMcYUW6W7aFFEjgJ7z5KlIRBTRtU5F1a/4inP9SvPdQOrX3FV9Pq1VNXgcy280gWTgohIRHGu8ixtVr/iKc/1K891A6tfcVX1+tlpLmOMMcVmwcQYY0yxVcVgMtXbFSiA1a94ynP9ynPdwOpXXFW6flWuz8QYY0zJq4otE2OMMSXMgokxxpjiU9UK9QCm48wRv9EjrTuwAvgd+C8Q5KZXB95309cDg9z0QGCdxyMGeCWPfYUBqR753i6gbs2BH4AtwCbgATe9PvAtsMN9ruemC/AazkySG4ALPMoa5+bfAYzLZ395llva9QN6uMd7k5t+Uz77uw046nH87izD45ftsd/5+ezPH/jE3X4lEFZGx++S0z5/acC1Xjh+Hdy/Yzrwt9PKGgZsc+v+cHGPX0nVLb9y8tjfICDR49j9vQyPXSTOd846ICKf/eX72S3l49f+tM/eMeDPxT1+qlohg8nFwAWcGkxWAwPd5TuAZ9zl+4D33eUQYA1QLY8y1wAX55Ee5rmfQtStCSe/MAKB7UAn4EXcf0jgYeAFd/kKnKmLBegLrPT4gOx2n+u5y2cEivzKLYP6tQPaustNgUNA3Tz2dxvwRlkfP3ddciH2dy/uDwScKag/Kav6eZRZH4gDanrh+IUAvYDnOPULxwfYBbTG+UG2HuhUnONXgnXLs5w89jcIWFDWx85dFwk0LGB/BX42Sqt+p/2dD+NcrFis46daAYOJ+0bDODWYHOPkYILmwGZ3+U1gjEe+JUDv08pqC+zP3f5s+zmHes4DLsf5hdfE40OxzV1+BxjtkX+bu3408I5H+in5Ts9/ermlXb88ylmPG1xOS7+NInwZlmT9KFwwWQT0c5d9cVqoZ3wOSvP4AROB2fmUX6rHzyPfk5z6hd0PWOTx+hHgkZI8fudat/zKySN9EEX8Miyp+lG4YFKo/63SPH7AEOCXfNYV+fhVlj6TjcA17vJInIACzpfcCBHxFZFWQE+PdblG4/yi0nzKbiUia0XkRxEZUNgKiUgYcD5O87+Rqh4CcJ9D3GzNcAJZrig3Lb/00+VXbmnXz7Oc3ji/Xnfls6s/iMgGEflMRE4/9qVZvwARiRCRX0Xk2nx2c2J7Vc3CadY3KKP65RoFfHyWXZXm8ctPYT9/53T8ilm3/MrJSz8RWS8iX4tI53Ms91zqp8BiEVkjIhPzyVPYY1wa9ctV0GevSMevsgSTO4D7RGQNThMww02fjvNHigBeAZYDWadte7YDeghooarnAw8CH4lIUEGVEZHawOc45yKPnS1rHml6lvQSUQL1yy2nCfABcLuq5uSR978459G7Ad8BM8uwfi3UuXXEzcArInJeEbcv7frlHr+uOL/w81Laxy/fIvJIy+u4FPn4lUDdClvObzinb7oDrwNflVC5hXGRql4ADMf5Xro4r13lkVaSn72CyqmO8wN8bj5Zinz8KkUwUdWtqjpEVXviBIZdbnqWqv5FVXuo6gigLk5HFQAi0h34//buJjSuKgzj+P+pKUqjhEjVgIq1oFRXirVKdSGoBQsGxA8qiIt2k4W0K1d2Y0TqyrViuxFcalRQrBBbRLBaWmm1FrQNLvwghWAtQaxVXhfvGXM7zOTrzkyd+PygzJmbO2fenHsn75x7T88ZiIgjbeo9HxEzpXyk1HvrfLFIWk0e7Lci4p2yebr84Wj8ATlTtv/IxT2lG4Cf59nerF293Y6PklQ/AHZHxKFW7xURg4sa7gAAA6tJREFUMxFxvjx9g+wZ9iS+iGg8TgEHyW9yzf59vaQBYIi8f9H1+IqngImIuNDqvXrQfu0s9vxbUvt1KLZ29VwkIs5FxGwpfwislrR2GfUuOb7KuXcGmAA2tdhtsW3c8fiKR4CjETHd5ndYcvutiGQi6dryuArYDbxWnq+RNFjKDwN/RcS3lZc+zTzdPEnXSLqslNeT91em5tlfwD7gZES8WvnR++ToLMrje5XtzyrdC/xWuqr7gS2ShiUNk9c2W317bVdvV+Mr32omgDcjot03m8bJ3TBKjkTpRXzDki4vda4F7gOqx71VvU8An8xzubOTx7dhofOv2+3XzmHgFkk3l2O9rdTRbNHt16nY5qmneb+Rsm/jUuwqYGYZ9S41vkFJVzXK5Gf3mxa7LnRudCW+ioXOvSW1H9B/N+BLA/wCXCCz+w5gFzm64TvgFeZuxq8jb1CdJC8T3NRU1xSwoWnbKDBeyo+Tw/COkd2+RxeI7X6yq3qcuSF1W8nryJNkr2gSuLrsL3KQwGlyKOHGSl3byWGDp8jLSI3texv7tau32/EBz5T2rw4xvKP8bBwYLeU9lfY70NzWXYxvM3PDwb8GdlTeoxrfFWQ3/xTwJbC+h8d3HfATTaMLe9x+I+Rn6BxwtpQbw+q3kp+n08ALdduvU7G1q6e8ZgwYK+XnKm13CNjci7YjR8AdK/9ONLVdNb6250YPju0aMjEMNb3HstsvIjydipmZ1bciLnOZmdml5WRiZma1OZmYmVltTiZmZlabk4mZmdXmZGJmZrU5mZj9BzX+s6xZv3AyMatJ0kuSdlWevyxpp6TnJR1WTtT4YuXn7yonATyhykSAkmYljUv6gpy516xvOJmY1bePMqVFmdJnGzBNTr+ziVxM7K7KhH/bI+eR2wjslNSYaXeQXPLgnoj4rJe/gFldA5c6ALN+FxE/SJqRdCdwHfAVuTDRllIGuJJMLp+SCeSxsv3Gsn2GXB3y7V7GbtYpTiZmnbGXXMxqhFz64EFgT0S8Xt1J0gPAQ+SiUr9LOkjOcQXwR0T83auAzTrJl7nMOmOCXDf9bnKG5/3AduX6E0i6vsxuPQT8WhLJBnLJVrO+556JWQdExJ+SDgBnS+/iY0m3AZ+XmbxnydmWPwLGJB0nZ7RuuRaMWb/xrMFmHVBuvB8FnoyI7xfa32yl8WUus5ok3U6u6THpRGL/V+6ZmJlZbe6ZmJlZbU4mZmZWm5OJmZnV5mRiZma1OZmYmVlt/wB1Aikz09CaQAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot time series of nominal and real (2018$) expenditures for grocery stores\n",
+    "# Note that the 2018 values for both series should be equal\n",
+    "(data_constant_dollar\n",
+    " .loc[data_constant_dollar['store_type'] == 'grocery_stores', :]\n",
+    " .set_index('year')\n",
+    " .drop(columns='store_type')\n",
+    " .plot())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use convert_currency() to Convert USD to British Pounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>year</th>\n",
+       "      <th>store_type</th>\n",
+       "      <th>expenditure</th>\n",
+       "      <th>expenditure_2018</th>\n",
+       "      <th>expenditure_2018_GBP</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1997</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>270956.91</td>\n",
+       "      <td>423875.807122</td>\n",
+       "      <td>331152.511569</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1998</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>273638.88</td>\n",
+       "      <td>421528.097543</td>\n",
+       "      <td>329318.366023</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1999</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>283782.47</td>\n",
+       "      <td>427793.590858</td>\n",
+       "      <td>334213.275836</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2000</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>286669.78</td>\n",
+       "      <td>418029.852893</td>\n",
+       "      <td>326585.366209</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2001</td>\n",
+       "      <td>grocery_stores</td>\n",
+       "      <td>296436.72</td>\n",
+       "      <td>420391.299188</td>\n",
+       "      <td>328430.243550</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   year      store_type  expenditure  expenditure_2018  expenditure_2018_GBP\n",
+       "0  1997  grocery_stores    270956.91     423875.807122         331152.511569\n",
+       "1  1998  grocery_stores    273638.88     421528.097543         329318.366023\n",
+       "2  1999  grocery_stores    283782.47     427793.590858         334213.275836\n",
+       "3  2000  grocery_stores    286669.78     418029.852893         326585.366209\n",
+       "4  2001  grocery_stores    296436.72     420391.299188         328430.243550"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from datetime import date\n",
+    "\n",
+    "# Apply the convert_currency() method to the 'expenditure_2018' column\n",
+    "# Use the exchange rate from Dec. 31, 2018, since our data are in 2018$\n",
+    "data_constant_pounds = (\n",
+    "    data_constant_dollar\n",
+    "    .convert_currency(\n",
+    "        column_name='expenditure_2018',\n",
+    "        from_currency='USD',\n",
+    "        to_currency='GBP',\n",
+    "        historical_date=date(2018,12,31),\n",
+    "        make_new_column=True)\n",
+    ")\n",
+    "data_constant_pounds.head()                    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot Time Series to Observe Currency Conversion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x1e4836d32b0>"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZMAAAEGCAYAAACgt3iRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOzdd3xUVd7H8c9JL6QXEggQSugEkEBAqiKCKJa1gYCoqIiy+qyrYnn2se+q2ywrVpAiiqLrgiwISldqQu81gRAgvbcp5/nj3oQEAiQkYVJ+79drXjNzbpkzYZjvnHvOPVdprRFCCCFqwsnRFRBCCNHwSZgIIYSoMQkTIYQQNSZhIoQQosYkTIQQQtSYi6MrUNuCg4N1ZGSko6shhBANSnx8fJrWOuRKt290YRIZGUlcXJyjqyGEEA2KUiqxJtvLYS4hhBA1JmEihBCixiRMhBBC1JiEiRBCiBqTMBFCCFFjEiZCCCFqTMJECCFEjTW680yEEEJUQ0EGGxd9UuPdSJgIIURTY7fB0VWw/UtsB/7LALulxruUMBFCiKYi7Qjs+BJ2LoDc05S4+TO/5HqORtwOjK/RriVMhBCiMSvKgb0/wI75cHIzKCfoMIIDvf+XO1f60rFlEPMfiuXNqRImQgghyrPbIfFX2D4f9i0CayEEd4QbXoWeY9mT48nYTzfRIsiDLx7oi5dbzaNAwkQIIRqLzETY8RXs/AqyToC7L/QcC70nQMs+oBTHUvOYNGsjfp6uzJ3cD38vt1p5aQkTIYRoyOw22PcfiPsCEtYDCtoNhev/D7rcAq6eZaueyS5i4swtaGDe5H6E+3ledLfVJWEihBANkc0Ke76DdX+F9CMQEAnXvQQ9x4F/qwtWzyoo4f5Zm8kqKGHBowNoF9KsVqsjYSKEEA2JzWKMxlr/d8g8Ds27wz1zofMYcKr8PPSCEisPzd5KQloBsx/sS48Iv1qvVpXPgFdKOSultiullpjPZyuljiuldpi3Xma5Ukq9r5Q6opTapZS6ptw+JimlDpu3SeXK+yildpvbvK+UUmZ5oFLqZ3P9n5VSAbX31oUQogGxFkPcLPjgGlg8DTx8YexXMGU9dL3tokFisdl5fP42dpzM4r2xvbi2Q3CdVK8606k8Bew/r+xZrXUv87bDLLsJiDJvjwIfgREMwMtALNAPeLlcOHxkrlu63Siz/HlgpdY6ClhpPhdCiKbDUgRbPoP3e8OSP4B3KNy3EB5dC51vvmiIANjtmmcW7mTNwVTevKMHN/UIr7NqVilMlFIRwM3A51VY/TZgrjZsAvyVUuHASOBnrXWG1joT+BkYZS7z1Vpv1FprYC5we7l9zTEfzylXLoQQjVtJAWycAe/1hKXPgF8rmPgDPPwLdLwRjAM4F6W15rUl+1i0I5lnR3ZiXL/WdVrdqvaZvAs8B/icV/6mUur/MFsNWutioCVwstw6SWbZpcqTKikHaK61Pg2gtT6tlAqtrHJKqUcxWja0bl23fzAhhKhTxXnG4awN70N+KkQOhjs/M+4vEyDl/WvVEWZvSGDyoLY8Pqx9HVbYcNkwUUrdAqRoreOVUsPKLXoBOAO4AZ8C04HXgMrerb6C8irTWn9q1oGYmJhqbSuEEPVCca5xOGvjv6AgHdpdB0OfgzbXVntXX25K5O8/H+J3vVvy0uguqGqE0JWqSstkIHCrUmo04AH4KqW+1FpPMJcXK6W+AJ4xnycB5celRQDJZvmw88rXmOURlawPcFYpFW62SsKBlKq+MSGEqJcshZCTDNlJxn1OEmSdNM5UL8qCqBthyHPQqu8V7f6/u07zp0V7uL5zKG/fFY2TU90HCVQhTLTWL2C0QjBbJs9orSeU+5JXGH0Ze8xNFgPTlFILMDrbs831lgN/LtfpfiPwgtY6QymVq5TqD2wG7gc+KLevScBb5v2imr9lIYSoI9ZiMyBOQfYp477ssRkeBekXbucVBJGDYPAfoeU1Fy6vol8Pp/E/32wnpk0AH953Da7OV++SVTU5z2S+UioE4zDVDuAxs3wpMBo4AhQADwKYofE6sNVc7zWtdYb5eCowG/AElpk3MELkW6XUZOAEcHcN6iuEELWvIAN+/hMcWgH5lRw88fAD3wjwawktY4x7X/PmFwG+LSqcpX6ldp7M4tF5cbQPacbnk/ri6eZc431WhzIGUDUeMTExOi4uztHVEEI0BQeXwY9PGa2N7ndCYDszJFoaAeLbAtxr90zzyhxJyePujzfQzMOF7x+7llBfj2rvQykVr7WOudI6yBnwQghRXYWZsOx52LXAOAN9/EII7+mQqpzKKuT+mZtxdnJi3kOxVxQktUHCRAghquPgT0ZrJD/V6Cgf8iy41M7Mu9WVllfMxM83k1tkZcGU/kQGezukHiBhIoQQVVOYCT+9ADu/htBucN830KKXw6qTU2Rh0qwtJGcXMm9yLN1a1P58W9UhYSKEEJdzaLnRGslLMVoiQ55zWGsEoMhi4+E5cRw8k8tn98fQNzLQYXUpJWEihBAXU5hltka+gtCuMO5raNHboVWy2Ow8MX8bWxMyePfeXlzXudKJQa46CRMhhKjMoRXw45NGa2TwM8bZ6C7uDq2S3a55duFOVh5I4fXbu3Nbr5aX3+gqkTARQojyCrNg+YuwYz6EdDGmea/BiYS1RWvNqz/u5T/mxI0T+7dxdJUqkDARQohSh3+GxU9C3lnjbPSh0x3eGin1z18OM2djIo8MvjoTN1aXhIkQQhRlw08vwo4vzdbI/HrRGik189fjvL/yMPfERPDiVZq4sbokTIQQTduZPfDNeMg6AYOehmHP15vWCMD38Um8vmQfo7qF8ec7etTLIAEJEyFEU7ZrISz+PXj6w4M/QetYR9eoghV7z/Dc97sY2CGI98b1wuUqTtxYXRImQoimx2aBn/8PNs2A1tfC3bPBp7mja1XBhqNpTPt6Oz1a+vHpxBjcXa7uxI3VJWEihGha8lJg4QOQ+BvEToUbXwdnV0fXqoJdSVk8MieOyCAvvnigL97u9f+ruv7XUAghasvJrfDtRGP47x2fQs97HV2jCxxJyWXSrC0EeLsxb3IsAd6OO9O+OiRMhBCNn9YQ/wUsfc6YFn7yCgiPdnStLpCUWcCEz7fg4uzE/Idjae6gGYCvhISJEKJxsxTB0mdg+zzocAP87jPwcvxcVudLzS1m4swtFJRY+WbKANoEOW4G4CshYVIb7HY4utL4sHqHwHUv1csPqxBNTtZJ47BW8nZjgsZhL4BT/evIzi40ZgA+nV3I/Idj6RLu6+gqVVuVw0Qp5QzEAae01rcopeYDMYAF2AJM0VpbzOvELwKOm5v+W2v9mrmPUcB7gDPwudb6LbO8LbAACAS2ARO11iVKKXdgLtAHSAfu1Von1Owt16L8NCNA4r6ArETwCoaiLNi3CG56B7rdAfV0TLgQjd7xdUZHu7XEmBKl882OrtEFiiw2/rP9FJ+sO0ZSZgGfT+pLnzYN84dodQYtPwXsL/d8PtAZ6IFx7faHyy1br7XuZd5Kg8QZ+BC4CegKjFNKdTXXfxv4p9Y6CsgEJpvlk4FMrXUH4J/meo6lNZzYBN8/Av/oAr+8An6t4K5Z8PR+eHSNcV3n7x6Er8dBdpKDKyxEE6M1/PY+zL3N+IH36Op6FySZ+SX8a9VhBr29muf/vRsvN2dmTurL0I4hjq7aFatSy0QpFQHcDLwJPA2gtV5abvkWIOIyu+kHHNFaHzO3WQDcppTaD1wP3GeuNwd4BfgIuM18DPAd8C+llNKOuHB9cS7s+ga2zoKUveDuC30ehJiHILTzufXCesDDK2Hzx7DqDfiwP9zwMsRMBqf6e8KREI1CcR4sngZ7f4Aut8LtM8Ddx9G1KnMyo4DP1x/j27gkCi02hnYMYcqQdgxoH1Rvz2yvqqoe5noXeA644F9FKeUKTMRouZQaoJTaCSQDz2it9wItgZPl1kkCYoEgIEtrbS1XXjqvctk2WmurUirbXD/tvDo8CjwK0L2lN6x8DYI7QlAUBHcAjxpcgezsXtg60wiSkjwIi4Yx70GPu8HtIh1kTs4w4Anj19CSPxidf7sXwpj3KwaPEKL2pB+FBeMh7SDc8CoMfKreHGbeeTKLT9cfY9nu0zg7KW7t2ZJHhrSlc1jD6xu5mMuGiVLqFiBFax1v9oecbwawTmu93ny+DWijtc5TSo0G/gNEAZX9q+pLlHOZZecKtP4U+BQgprW35td3QdvOrdCsuRkuHYz74CjjsX/ryjvjrMVGv8fWmXByE7h4QLffQd/J0LJP1T+gAZEw4d9GEP30PHwy2JiJdNAf6tXcP0I0KMV5xqy+uach94x5Ow3b5hn/nyf8G9pf5+haYrdrVh9M4dN1x9h8PAMfdxceGdKOB69tS5hfwxnyW1VVaZkMBG41g8ED8FVKfam1nqCUehkIAaaUrqy1zin3eKlSaoZSKhijxdGq3H4jMFouaYC/UsrFbJ2UllNumySllAvgB2RcsrahXeB/N0JmAqQdgrTDxi39MOz7j3Ed51LO7hDU3gyXKOM+Zb/RqV6QDoHt4MY3oNf4Kx+dpRT0HAvth8PyF2DNX4wm+K0fQKt+V7ZPIRobrY2Wf+5ZyDtTMSRyz5QLj7NQknvh9i4e0DLGOKwV4NjrfBRbjU71z9Yf50hKHi38PPjfm7twb99W+HjUrzPta5OqTveD2TJ5xhzN9TDwEDBca11Ybp0w4KzWWiul+mH0dbTBGMF1CBgOnAK2AvdprfcqpRYC32utFyilPgZ2aa1nKKWeAHporR9TSo0Ffqe1vudSdYyJidFxcXEXXyE/3QiW84Mm47jRmlHO0OkmoxXSdljt93Mc/tk49JWdBP0egeH/V3vHdC2Fxn+qetK0b3LyUsCtGbh5ObomV1dJgTE0/lS8cU6Htcho3Ze/t5WYzytZZjWXXXjQwfg8+4RBszDjvvR2/nMPf4d/7rMLLHy5OZHZGxJIzS2ma7gvjw5px83R4bjW4wkaSyml4rXWMVe8fQ3CxAokAqU/E/6ttX5NKTUNmApYgULgaa31BnP70Rj9L87ALK31m2Z5O84NDd4OTNBaFyulPIB5QG+MFsnY0g78i7lsmFyMtcRozXj41f2Eb8V5Ruf85o+Ns3Fv/gd0GlW1bbWGnFPngjDtkBmOh43y5t1h5JvQblhdvgNRqiQf9nxvDA9P3maUefiBT7j5RdfCvA8H3/Bz5c2a17v5oKqlMAsOLYcDP8LhX8BaCE4u4OptHMJ18QAXN/PeveK9c2Xl7kYfpE+48bcp/Tt5+Dk8JC6nyGLjg1WH+eK3BApKbAzpGMKjg9sxsEPD6lS/qmHSEFxxmDhCUpwx/XXKPqNP5qa3oVmoscxSCOlHKgmNI2DJP7cPNx/j8FxwR/BvZfTPZJ2AjjcZh+iCOzjmvTV2Z/YY03Ps+haKcyCkM0TfC2jjsExO8rlDNXlnwG49bwfKOMHVJ8z4QVH6a9szwPgC9fAzpkX38DN+dXv4GV+2jvxyykuBA/+F/T/C8bXGe/IJh863QJcx0GYgODet86C3ncjk2YU7OZqaz609WzB1WPsGecIhSJhcoEGFCRgtot/eg3XvgKuX0cGfftg4c7f8OAS/VudCI7h0IEFH41dc+S8YS5Exrfb6fxi/Fvs+AkOfkzPya4Ol0OjvivsCkrYYfW7dbjeGiLfuf/EversdCtKMY/45p8t1HCdX7BfIT7306zu5nAua0oApHzieAcYPCv9Io9/AK6jm4ZOZCAeWGAFyYhOgjb7ELmOg8xjj89oEh7wXWWz84+dDfL7+GGG+HvzlzugGfY4ISJhcoMGFSanUQ0YHfV7KuaAoDY3A9tU/Dp+XAqvfhG1zjS+boc8b/UAN+dCKo6QcMFohO782Lu8a1MEIkF731W5I26xGK6cw03idomxjRoWibOOwUqXPzbLCLLBbKu7P1dsYsRjQBvzbmPetzz2ubMi81pB60AiPAz/C6Z1GefMeRoB0uQVCu9b7Q091KT4xg2cX7uJYWj7j+rXmxdGdG0XHuoTJeRpsmNSVM3tgxUtwbI0xYu3GN6DjyCb9ZVAlliLYv9hohZzYAE6u0PVWI0QiB9W/v5/Wxom1WSfMW6LRqij/+PxRUB7+FQNGOcHBZUbLGKBVrHkI6xajNdLEFZbY+NuKg8z67Tgt/Dx5+85oBkUFO7patUbC5DwSJpXQ2ugsXfGS0Q/TbhiM/DM07+bomtWM3W4MOijtS8pMMI7Zu/sYMxS4+5qPfcqVmY9dPSsPhLQjRitkx1dQmAEBbaHPA8bw8GYN+DCG1kaLpyxkzgubrBPG1QfbDjZaIJ1uNgYMCAC2HM/gue92kpBewMT+bZh+U2eaNYALVlWHhMl5JEwuwWYxTsRc8xfjcMo19xszHJd2+tdXxbnmYIQj50aupR2GjKNgKTi3nosnaDvYii+/T+V8YcDYLcbwVicXY/aCPg9C26FNo0/AbjeG77o2vpPpaqKgxMo7Px1kzsYEIgKM1si17RtPa6Q8CZPzSJhUQUEGrH0Htn5mfAEP+aNx+VJHfpGUntWccezcuT9ph40QyT19bj3lZByWKT3JNKjDuZNOfcKM1oa12NhfcY4RRBVulyizFkPUCOg9sd5dD1xcfRuPpjP9+12cyCjggWsjeXZkpwZx+dwrJWFyHgmTakg7DCv+BIeWGV/QN7xq9Kc4uxm/zmvSL1B6RnNeijFKKS/FCIvSx2X3KcZ9+RYGGMfzy2Ym6HAuPALbyVQ0ok7lF1t5a9kB5m1KpE2QF+/cGU1suyBHV6vO1TRMGm/MissLjoL7FsDR1bD8JWPa/PKcXI1gcXY1b+bjysqdXIzHRdlmcKQYQ5MvoIwhq81CjfMsIvoaw5u9Q4yygLZGvWpjWKsQ1fTbkTSmf7+LU1mFPDSwLc+O7ISnW/27mFZ9JGEijEnxHltvzF2WddLoO7BZjGPotnKPL1puNabDKM4FD19jFFCzUDMwQo2Oa+9QIzS8gprciW2i/ssrtvLnpfv5avMJ2gZ7s3DKAGIi5dys6pD/1cLg5Azd73R0LYS46gpLbIz/bBO7TmXzyOC2/PHGTni4SmukuiRMhBBNls2u+Z9vtrPrVDYfT+jDyG5hjq5Sg9UExjwKIUTl3lq2n+V7z/Knm7tKkNSQhIkQokmatymRz9YfZ9KANjw4MNLR1WnwJEyEEE3O6oMpvLxoD9d3DuVPt3RtUFPF11cSJkKIJmVfcg7T5m+jS7gvH4zrjUsDuHBVQyB/RSFEk3Emu4iHZm/Fx8OVmZP6Nuoz2q82CRMhRJOQX2xl8pyt5BZZmPVAX8L8ZB6y2lTlMFFKOSultiullpjP2yqlNiulDiulvlFKuZnl7ubzI+byyHL7eMEsP6iUGlmufJRZdkQp9Xy58kpfQwghqsNm1zz59Xb2n87hX/ddQ9cWDfNqiPVZdVomTwH7yz1/G/in1joKyAQmm+WTgUytdQfgn+Z6KKW6AmOBbsAoYIYZUM7Ah8BNQFdgnLnupV5DCCGq7PUl+1h5IIVXb+vOdZ3r+SzZDVSVwkQpFQHcDHxuPlfA9cB35ipzgNvNx7eZzzGXDzfXvw1YoLUu1lofB44A/czbEa31Ma11CbAAuO0yryGEEFXyxW/Hmb0hgYcHtWVi/zaOrk6jVdWWybvAc4DdfB4EZGmtrebzJKCl+bglcBLAXJ5trl9Wft42Fyu/1GtUoJR6VCkVp5SKS029zHW0hRBNxs/7zvLakn2M7NacF0Z3cXR1GrXLholS6hYgRWsdX764klX1ZZbVVvmFhVp/qrWO0VrHhIQ04KvhCSFqze6kbJ78ejvRLf14997eODvJuSR1qSrj4gYCtyqlRgMegC9GS8VfKeVithwigGRz/SSgFZCklHIB/ICMcuWlym9TWXnaJV5DCCEu6lRWIQ/N2UqgtxufTYqRaeSvgsu2TLTWL2itI7TWkRgd6Ku01uOB1cBd5mqTgEXm48Xmc8zlq7RxBa7FwFhztFdbIArYAmwFosyRW27mayw2t7nYawghRKVyiyxMnr2VohIbsx7oS6iPDAG+Gmpynsl04Gml1BGM/o2ZZvlMIMgsfxp4HkBrvRf4FtgH/AQ8obW2ma2OacByjNFi35rrXuo1hBDiAlabnSe+2s6RlDxmTLiGTmE+jq5SkyGX7RVCNApaa176zx6+2nyCt37Xg7H9Wju6Sg1KTS/bK2fACyEahc/WH+OrzSeYOqy9BIkDyMQ0QogGraDEypebEvnLsgPcHB3Oszd2cnSVmiQJEyFEg5SRX8KcDQnM3ZhAZoGFoR1D+PvdPXGSIcAOIWEihGhQTmYU8Pn6Y3wTd5Iii50buoTy2ND2xEQGOrpqTZqEiRCiQdibnM0na4/x392ncVJwW6+WTBnSjqjmMmKrPpAwEULUW1prNh5N56O1R1l/OA1vN2ceGhjJQ4PaEu7n6ejqiXIkTIQQ9Y7Nrlm25zSfrD3G7lPZBDdz57lRnRgf2wY/T1dHV09UQsJECFFvFFlsLIxP4rN1xziRUUDbYG/+8rse3NG7JR6uMiVKfSZhIoRwuOxCC3M3JDB7QwLp+SX0bOXPi6M7M6JrmEzQ2EBImAghHKbIYmPuxgQ+XH2U7EILwzqF8NjQ9sS2DcS4pJFoKCRMhBBXnc2u+fe2JP758yGSs4sY2jGEZ0d2ontLP0dXTVwhCRMhxFWjtWb1wRTeXnaQg2dziY7w42939+TaDsGOrpqoIQkTIcRVse1EJm8tO8CW4xlEBnnx4X3XMLpHmBzOaiQkTIQQdepoah5//ekgP+09Q3Azd16/vTtj+7bC1VnmmW1MJEyEEHXibE4R7/5ymG/jTuLh4sQfbujIw4Pb4u0uXzuNkfyrCiFqVU6RhU/WHmXmr8ex2TUT+7dh2vUdCG7m7uiqiTokYSKEqBXFVhtfbjrBv1YdJrPAwq09W/DHGzvSJsjb0VUTV8Flw0Qp5QGsA9zN9b/TWr+slFoPlM6wFgps0VrfrpQahnGt9uPmsn9rrV8z9zUKeA9wBj7XWr9llrcFFgCBwDZgota6RCnlDswF+gDpwL1a64Qav2shRK3afCydp7/dyamsQgZ1COb5mzrLMN8mpiotk2Lgeq11nlLKFfhVKbVMaz24dAWl1PcYAVJqvdb6lvI7UUo5Ax8CI4AkYKtSarHWeh/wNvBPrfUCpdTHwGTgI/M+U2vdQSk11lzv3it+t0KIWheXkMGDs7fS3NeDeZP7MTgqxNFVEg5w2eEU2pBnPnU1b2UXjldK+QDXA/+5zK76AUe01se01iUYLZHblDEu8HrgO3O9OcDt5uPbzOeYy4crGUcoRL2x82QWD36xlTBfD76Z0l+CpAmr0tg8pZSzUmoHkAL8rLXeXG7xHcBKrXVOubIBSqmdSqllSqluZllL4GS5dZLMsiAgS2ttPa+8wjbm8mxz/fPr96hSKk4pFZeamlqVtySEqKF9yTncP2sL/t6uzH8kllAfD0dXSThQlcJEa23TWvcCIoB+Sqnu5RaPA74u93wb0EZr3RP4gHMtlspaFPoS5Zfa5vz6faq1jtFax4SEyC8jIera4bO5TJi5GW83Z756uL9cW0RULUxKaa2zgDXAKAClVBDG4av/llsnp/SwmNZ6KeCqlArGaHG0Kre7CCAZSAP8lVIu55VTfhtzuR+QUZ06CyFq17HUPO77fDMuTor5j/SnVaCXo6sk6oHLholSKkQp5W8+9gRuAA6Yi+8Glmiti8qtH1bar6GU6me+RjqwFYhSSrVVSrkBY4HFWmsNrAbuMncxiXOd+YvN55jLV5nrCyEc4GRGAeM/34zdrpn/cCxtg2XYrzBUZTRXODDHHI3lBHyrtV5iLhsLvHXe+ncBU5VSVqAQGGsGgFUpNQ1YjjE0eJbWeq+5zXRggVLqDWA7MNMsnwnMU0odwWiRjL2SNymEqLnkrELGfbaJQouNrx/pL9deFxWoxvZDPyYmRsfFxTm6GkI0Kik5RdzzyUbS80r46pH+9IiQc0gaG6VUvNY65kq3lzPghRCXlJZXzH2fbyYlt5h5k2MlSESlZNpOIcRFZRWUMOHzzSRlFjDrgb70aRPg6CqJekpaJkKISuUUWbh/1haOpeUzc1IM/dtdcIqXEGWkZSKEuEB+sZUHv9jK/tM5fDT+GjmzXVyWtEyEEBUUltiYPGcrO05m8eF9vRnepbmjqyQaAGmZCCHKFFlsPDovjs3HM/jHPT0Z1T3c0VUSDYSEiRACgBKrnSfmb2P94TTeuTOa23q1vPxGQpgkTIQQFFlsPLVgOysPpPDmHd25O6bV5TcSohzpMxGiCdJaczglj3WHUll/OI3Nx9Mpstj5v1u6Mj62jaOrJxogCRMh6gmbXePsVHeX60nLK+a3I2msO5TGr0dSOZtTDECH0GaM7duaG7s259oOwXX2+qJ+sms7e9L21Hg/EiZCOJjNrnn3l0N8tOYo/l6utAnypk2gl3Ef5GXevAnwcqU614YrttqIT8hk3eE01h9OZW+ycckhfy9XBnUIZkhUCIOigmnhL9PHNzV5JXlsSN7A2qS1/HrqVzKKaj4Zu4SJEA6UVVDCUwt2sPZQKjd1D8PXw5XEjHw2Hkvn39tPVVjXx8OlLFjaBHoRGeRN6yDjPtTHHaWo9NCVq7OiT5sAnh3ZicFRwXRr4VenLSBRPyXmJLIuaR1rk9YSfzYeq92Kj5sPg1oOYkjEEMYwpkb7lzARwkH2nMpm6vx4zmQX8eYd3bmvX+sKLY8ii42kzAIS0gpIzCggMT2fxPQC9p7KZvmeM1jt5yZpdXdxwtvdhYz8EgDah3gztm9rhnQMJrZtEN7u8l+9qbHYLGxL2ca6pHWsS1pHQk4CAO392jOx60SGRgylZ0hPXJxq57MhnzAhHOD7+CRe/GE3AV5ufDtlAL1bXzjnlYerMx1CfegQeuFU71abneSsIhIzjIBJTM8nq8BCTGQAg6JCaCmHrpqkjKIMfj31K2tPrmVD8gbyLHm4OrnSL6wf4zqPY0jEECJ8IurktSVMhLiKSqx2Xl+yj3mbEunfLpAPxl1DiI97tffj4uxE6yAvWgd5MTiqDioqGozUglR+PLHfhjEAACAASURBVPYjK0+sZHfqbjSaEM8QRkaOZEjEEPqH98fLte6vhilhIsRVcia7iMfnx7PtRBaPDG7L9FGdcXGWU71E9VnsFtYlreOHwz/w66lfsWkb3YK6MbXXVIZGDKVzYGec1NX9bEmYCHEVbD6WzhNfbaegxMq/7uvNLdEtHF0l0QAdzTrKD4d/4MdjP5JRlEGIZwgPdHuA2zvcTqRfpEPrdtkwUUp5AOsAd3P977TWLyulZgNDgWxz1Qe01jvM67+/B4wGCszybea+JgH/a67/htZ6jlneB5gNeAJLgae01lopFQh8A0QCCcA9WuvMGr5nIa4arTWzfkvgz0v30zrQi68eiaWjXO5WVENeSR4/JfzED0d+YFfqLlyUC8NaDeOOqDu4tsW1tdaBXlNVqUUxcL3WOk8p5Qr8qpRaZi57Vmv93Xnr3wREmbdY4CMg1gyGl4EYQAPxSqnFZjh8BDwKbMIIk1HAMuB5YKXW+i2l1PPm8+lX/naFuHoKSqxM/343P+5MZkTX5vz9np74erg6ulqiAdBaE382nh+O/MCKhBUU2Ypo79eeZ2Ke4ZZ2txDkWf+uLXPZMNHGReLzzKeu5u1SF46/DZhrbrdJKeWvlAoHhgE/a60zAJRSPwOjlFJrAF+t9UazfC5wO0aY3GZuBzAHWIOEiWgAjqfl89i8eA6l5PLsyE5MHdoeJzm3Q1zG2fyzLD66mP8c+Q8nck/QzLUZY9qP4Y4Od9A9uHu1Tlq92qrUPlJKOQPxQAfgQ631ZqXUVOBNpdT/ASuB57XWxUBL4GS5zZPMskuVJ1VSDtBca30aQGt9WikVepH6PYrRsqF169ZVeUtC1Jlf9p3lD9/uwNlJMfvBfgztKBeWEudorckpySG9KJ30wnQyijJIK0zjt1O/8Vvyb9i1nb5hfXms52Pc0OYGPF0axjDvKoWJ1toG9FJK+QM/KKW6Ay8AZwA34FOMFsNrQGXRqa+gvMq01p+adSAmJqZa2wpRW0qnRflg1RG6tfDl4wl9aBVY90MyhePZtZ20wrSycEgvSiej0LwvyjhXbt5btfWCfYR6hTK5+2Tu6HAHrXwb3qzN1eq50VpnmYelRmmt/2YWFyulvgCeMZ8nAeX/EhFAslk+7LzyNWZ5RCXrA5xVSoWbrZJwIKU69RXiaskpsvD7r7az9lAqd/WJ4I3bu+Ph6uzoaok6Ztd2lh1fxowdMziRe+KC5W5ObgR5BhHoEUiIVwidAjsR5BFUVlZ27xFEgEfAVR/OW5uqMporBLCYQeIJ3AC8Xe5LXmH0cZROO7kYmKaUWoDRAZ9trrcc+LNSqvRU3xuBF7TWGUqpXKVUf2AzcD/wQbl9TQLeMu8X1cabFqI2ZeaXMOmLLexLzuGN27szPrZ1vT62LWpOa82ak2v4YMcHHM48TFRAFM/3e57mXs0rBIS3q3eT+SxUpWUSDswx+02cgG+11kuUUqvMoFHADuAxc/2lGMOCj2AMDX4QwAyN14Gt5nqvlXbGA1M5NzR4mXkDI0S+VUpNBk4Ad1/pGxWiLqTkFjHx8y0cT8/nk4l95HrpTcCm05t4f9v77E7bTWuf1rw9+G1GtR3VoFsVtUEZg64aj5iYGB0XF+foaogmIDmrkAmfb+Z0dhGf3R/DoCi5FkhjtiNlBx9s/4AtZ7YQ5h3GY9GPcWuHW3F1ahzDvZVS8VrrmCvdvn6c7SJEA5OYns99n20mp9DC3Mn96BsZ6OgqiTpyMOMgH2z/gLVJawn0CGR63+nc3elu3J2rP6daYyZhIkQ1HUnJZfznmym22pn/SCzREf6OrpKoAwnZCczYMYNlCcvwcfPhyd5PMr7L+KsyaWJDJGEiRDXsTc7m/plbUEqx4NH+dA7zdXSVRC07nXeaj3d9zKIji3BzduORHo8wqdsk/Nz9HF21ek3CRIgq2n4ik0mztuDt7sL8h2NpF9LM0VUStSitMI3Pd3/Otwe/BWBc53FM7jGZYE/pC6sKCRMhqmDTsXQmz95KUDN35j8cKycjNiLFtmJm7Z7FF3u/oMRWwu0dbmdK9BTCm4U7umoNioSJEJex5mAKU+bF0yrQi/kPx9Lc18PRVRK1ZEPyBt7c9CYnck8wMnIkv+/9e9r4tnF0tRokCRMhLuGnPWf4/dfbiAr1Yd7kfgQ1kxE8jUFaYRrvbH2HZceX0ca3DZ+O+JQBLQY4uloNmoSJEBexaMcpnv52Jz1a+jHnwX74eTWO8wmaMpvdxsJDC3l/2/sU2Yp4vOfjPNTjIRnmWwskTISoxIItJ3jhh930iwxk5gN9aeYu/1Uauv3p+3l90+vsTttN//D+vBT7ksOvTtiYyP8QIc4z69fjvLZkH0M7hvDxhD54usmEjQ1ZXkkeH+74kK8OfEWAewBvD36bm9re1GTmzLpaJExqyK7t7ErdxcoTK1l9cjV+7n5MiZ7C4JaD5cPaAH24+gh/XX6Qkd2a8/643ri7SJA0VFprfk78mbe3vE1qYSr3dLqHJ695El83OTeoLkiYXAGL3UL82Xh+SfyFVSdWkVqYiouTC7HhsSRkJ/DEyifoFtSNx3s9LqHSQGit+evyg8xYc5Tbe7Xgb3f3xMW5aU/c15Al5Sbx581/Zv2p9XQO7My7171Lj5Aejq5WoyZhUkXFtmI2JW/i58SfWZO0huzibDxdPBnUchA3tL6BwRGD8XHzwWK3sOToEj7Z9YmESgNxLDWPF/69m83HMxjXrxVv3N4DZ7nEboNksVmYs28OH+/8GGflzHN9n2Nc53G4OMlXXV1rdLMGh3QM0VO/mEp4s3BaeLegRbMWhHmHEeYVhqtz9Ubj5FvyWX9qPSsTV7IuaR0F1gJ8XH0Y1moYw9sM59oW1170kprlQ+VU3ikJlXrIYrPz6bpjvLfyMO4uTrw4ugtj+7aSf58GKu5MHK9vep1j2ccY0WYEz/V9jjDvMEdXq8Go6azBjS5MgqKCdPSb0aQVplUoVyhCvEJo4d2C8GbhhHuHlz0uDR0vVy+yi7NZfXI1KxNXsiF5AyX2EgI9Arm+9fWMaD2CvmF9qxVKEir1046TWTz//S4OnMnlpu5hvHprN0LlZMR6xa7t5JbkklmUSVZxVtl9VnEWmcWZZBVVvE/MSaRls5a8GPsiQyKGOLr6DY6EyXlKr2dSbCvmTP4ZTuef5nTeaZLzk0nOS+ZM/hnjvuAMVnvF6zD7uvmSb8nHpm2Ee4czvPVwbmhzA71CeuHsVLOOWIvdwo9Hf+TTXZ9yKu8U3YO6M7XXVAmVqyy/2MrfVxxi9objhPi489pt3RnZTX691tTZ/LMcyTpCia0Ei91S4VZiK8FqtxrPbRWXlX9eaC2sEBhZxVnYtb3S13N1ciXAI4AA9wD8PfwJcA+gY0BHJnSdcNGjBeLSJEzOU9WLY9nsNtIK04ywyT9Ncl4yp/NP4+vmy/A2w+ka2LVOvuRrGioFlgKS85JJzk8uC8nS+zP5Z8r+Qw0IHyAhdZ41B1N46Yc9nMoqZEL/1jw3qjO+HjU7ETGzKJM1J9ew6uQq4s/G4+niSYB7QNkXXYCH8WUX6B5olJX7AvR392+wx/LP5J8h7mwccWfi2Hpma6XXP78YZ+WMq5OrcXN2LXvs4eKBv7u/8Tdz96/w+Pzg8HTxlM93LavzMFFKeQDrAHeMDvvvtNYvK6XmAzGABdgCTNFaW5RSwzCu1X7c3MW/tdavmfsaBbwHOAOfa63fMsvbAguAQGAbMFFrXaKUcgfmAn2AdOBerXXCperbUK60eLFQ6RHc41xAmAFXdp+fTHZxdoX9uDi5lB2yC/YKZlPyJtKL0okKiGJil4mMbje6yZ/dm55XzOtL9vGfHcm0D/HmrTuja3Qxq+S8ZFadWFUWIHZtJ8w7jIEtBmLTNrKKssgozjAOvxRlkmvJvei+/Nz9ykLHz92PZq7N8Hb1xsvVCy8XL7xdvSt97u1ilrl64eHsUedfrGfyz7D1zNayACkNDx83H/o070Pf5n3pGtQVT1dPXJ1ccXNyqxAUpcHholxq3MoXdeNqhIkCvLXWeUopV+BX4CmML/7Sa7V/BazTWn9khskzWutbztuPM3AIGAEkYVwLfpzWep9S6luM0FmglPoY2Gnu63EgWmv9mFJqLHCH1vreS9W3oYRJqfND5XxeLl60aNbCCIxK7oM9gytce7rEVsKy48uYu28uhzIPEegRyNhOY7mn0z0EeQZdzbfmcFprfth+iteX7COv2MrUYR144rr21T53RGvNkawjrDyxklUnVrE/Yz8AHfw7cF2r6y7bkrXYLGXH+TOLzNt5j0uP++db8imwFJBvyafEXlKl+jkrZ7xcvGjm1oxgz2BCPEMI8QohxDOEUK9Qgj2Dy+4DPAKqdK3y8uGx9cxWTuaeBCqGR9+wvnQM6Cjh0Ehc1cNcSikvjDCZqrXeXK78D0Cw1vqlS4TJAOAVrfVI8/kL5qK3gFQgTGttLb+eUmq5+XijUsoFOAOE6EtUuqGFSSmL3cJPx38iuzi7wqAAXzffK/rVqbVmy5ktzNs3j7VJa3FzcuPmdjczsetEogKi6uAd1C8nMwp48YfdrD+cRu/W/rx9ZzQdm/tUefvyJ6OuOrGq7Jd4z5CeXN/6eoa3Hl7ns8ta7BYKLAVl4ZJvza8QNvmWfAqs55bnluSSWphKWmEaKQUp5JTkXLBPF+VCsJcZOOVCJ8QrBIVie8p2tp7ZSlJeEmCER0zzGPqGGeER5R8l4dFIXZUwMVsV8UAH4EOt9fRyy1yBzcBTWuv1Zph8j9H6SMYIlr1KqbuAUVrrh83tJgKxwCvAJq11B7O8FbBMa91dKbXH3CbJXHYUiNVaVxiqpZR6FHgUoHXr1n0SExOv9O/RKB3PPs78/fNZdGQRRbYi+of35/6u9zOw5cAq/Uqtj0oHWJQOqjidf5qUghRAcSzFQvzxfNBu3NC5FUM6tMTbzRMvFy88XTwrvbk7u2O1W9l8ZjOrTqxi9cnVpBWmGSejhsVyfevrua7VdYR4hTj6rVdZsa2Y1IJz4ZJamEpqQWrF+8LUCodOfd18jZaHhEeTc7VbJv7AD8DvtdZ7zLLPgHyt9f+Yz30Bu3lYbDTwntY6Sil1NzDyvDDpB7wGbDwvTJZqrXsopfaa25QPk35a6/SL1bGhtkyuhqyiLL47/B1f7/+alMIU2vq1ZUKXCYxpP6ZejYDRWpNdnF3WT1QaGqUj807nnya9qOJHQKHwcwskp6gEG8Uop6odIiq/vbNyxqqteLl4MajlIIa3Hl52MmpjVmwrJq0wjWJrMZF+kQ32B4aomZqGSbWGkmits5RSa4BRwB6l1MtACDCl3Do55R4vVUrNUEoFY7RUWpXbXQRGyyUN8FdKuWitreXKKbdNknmYyw/IqN5bFKX8Pfx5uMfDTOo6ieWJy5m7dy6vb3qdD7Z/wN0d72Zc53F18svbareSXZxNdkk2OcU5ZY+ziyvesoqzOFtwltP5pym0FlbYh7uzO+HexvlBnQI7EeYdVtZ3FOYVxsq9xbzx4yH8vVx5Y0w3bu4RRrG9mEJroXGzFJ57XO5WYC0oe2y1W+nTvA+x4bFNatCCu7M7LZu1dHQ1RANXlQ74EMBiBoknsAJ4GwgDHgKGa60Ly60fBpzVWmulVD/gO6ANxgiuQ8Bw4BRGB/x95iGwhcD35Trgd2mtZyilngB6lOuA/53W+p5L1VdaJlWntSb+bDzz9s1j9cnVODs5E+YVhouTC87K2bh3Mu5LR+GUvy+/3Fk546ycKbAWlIVDTokRHHmWvIvWQaHwdffFz80PP3c/Qr1Cy0KjNCzCm4UT4B5Qad9RsdXGK4v38vWWk1zXKYR/3tsLfy+3uvyzCdEoXY2WSTgwx+w3cQK+1VovUUpZgURgo/mfvHQI8F3AVHN5ITDW7DC3KqWmAcsxgmWW1nqv+RrTgQVKqTeA7cBMs3wmME8pdQSjRTL2St+ouJBSipiwGGLCYjiRc4LvDn9HakEqNrsNq7ZitRs3m7aVPS7RJReUlT632W14uXrh6+5LsGcw7f3b4+duhERpWJz/2MfN54oPq6TkFjH1y23EJ2byxHXteXpEJ5lTSwgHabInLYqGbefJLKbMiye70MJf747mlugWjq6SEA3aVe0zEaI++D4+iRd+2E1IM3e+n3otXVvI9SmEcDQJE9FgWG12/rLsADN/Pc6AdkF8OP4aAr2lf0SI+kDCRDQImfklTPt6G78dSeeBayN56eYuuMrFq4SoNyRMRL134EwOj8yN42x2Me/cFc09Ma0uv5EQ4qqSMBH12k97TvP0tztp5u7Cgin9uaZ1gKOrJISohISJqJfsds27vxzi/VVH6NXKn08m9qG5XLxKiHpLwkTUO7lFFv7wzU5+2X+Wu/tE8Prt3fFwbVrzQ1ksFpKSkigqKnJ0VUQj4+HhQUREBK6uNbuWz/kkTES9cjwtn0fmxnE8LZ9XxnRl0rWRTfIiSElJSfj4+BAZ2TTfv6gbWmvS09NJSkqibdu2tbpvCRNRb6w5mMKTX2/H2Ukxb3I/rm0f7OgqOUxRUZEEiah1SimCgoJITU2t9X1LmAiHS8sr5u1lB1gYn0TnMB8+uz+GVoFejq6Ww0mQiLpQV58rCRPhMFabnfmbT/D3FQcpKLExZWg7nhoehZebfCyFaGjkrC/hEFsTMhjzr994efFeoiP8+el/hvDCTV0kSEQFw4YNo3SuvdGjR5OVlUVWVhYzZsxwcM3E+SRMxFWVklvE09/s4O6PN5JdUMKM8dcwb3I/OoQ2c3TVRD23dOlS/P39rzhMbDZbHdRKlJKfgeKqsNrszNmYyLs/H6LIauPxYe2Zdn0HaYlUwas/7mVf8oXXc6+Jri18eXlMt0uu8+WXX/L+++9TUlJCbGwsL774IjfccAMbN24kMDCQoUOH8qc//YmOHTsyatQoYmNj2b59Ox07dmTu3Ll4eXkRHx/P008/TV5eHsHBwcyePZvw8HCGDRtGbGwsq1evJisri5kzZzJ48GAKCwt58MEH2bdvH126dKGw8NxF0iIjI4mLi+P555/n6NGj9OrVixEjRnDzzTfzt7/9jSVLlgAwbdo0YmJieOCBB4iMjOShhx5ixYoVTJs2jb59+/LEE0+QmpqKl5cXn332GZ07d67Vv21TJf+TRZ3bdCydlxft5eDZXIZ0DOGVMV1pFyItkfps//79fPPNN/z222+4urry+OOPs3btWqZPn85jjz1GbGwsXbt25cYbbyQhIYGDBw8yc+ZMBg4cyEMPPcSMGTN46qmn+P3vf8+iRYsICQnhm2++4aWXXmLWrFkAWK1WtmzZwtKlS3n11Vf55Zdf+Oijj/Dy8mLXrl3s2rWLa6655oK6vfXWW+zZs4cdO3YAsGbNmku+Fw8PD3799VcAhg8fzscff0xUVBSbN2/m8ccfZ9WqVbX7x2uiJExEnTmbU8Sfl+5n0Y5kWvp78snEPtzYtbmMUqqmy7Ug6sLKlSuJj4+nb9++ABQWFhIaGsorr7zCwoUL+fjjj8u+zAFatWrFwIEDAZgwYQLvv/8+o0aNYs+ePYwYMQIwDjOFh4eXbfO73/0OgD59+pCQkADAunXrePLJJwGIjo4mOjq6xu/l3nvvBSAvL48NGzZw9913ly0rLi6u8f6FQcJE1DqLzc7s3xJ495dDWOyaJ6/vwNRhHfB0a1pnsTdkWmsmTZrEX/7ylwrlBQUFJCUlAcaXs4+PD3DhcFOlFFprunXrxsaNGyt9DXd3dwCcnZ2xWq0Vtq0OFxcX7HZ72fPzZw3w9vYGwG634+/vXyEERe25bAe8UspDKbVFKbVTKbVXKfWqWd5WKbVZKXVYKfWNUsrNLHc3nx8xl0eW29cLZvlBpdTIcuWjzLIjSqnny5VX+hqi/tpwJI2b3lvPm0v3E9suiBX/M4Snb+wkQdLADB8+nO+++46UlBQAMjIySExMZPr06YwfP57XXnuNRx55pGz9EydOlIXG119/zaBBg+jUqROpqall5RaLhb179174YuUMGTKE+fPnA7Bnzx527dp1wTo+Pj7k5uaWPW/Tpg379u2juLiY7OxsVq5cWem+fX19adu2LQsXLgSMwNy5c2dV/yTiMqoymqsYuF5r3RPoBYxSSvUH3gb+qbWOAjKByeb6k4FMrXUH4J/meiilumJcw70bMAqYoZRyNq8t/yFwE9AVGGeuyyVeQ9QjWmu2n8hk6pfx3Pf5ZoqtNj6/P4ZZD/QlMtjb0dUTV6Br16688cYb3HjjjURHRzNixAgSEhLYunVrWaC4ubnxxRdfANClSxfmzJlDdHQ0GRkZTJ06FTc3N7777jumT59Oz5496dWrFxs2bLjk606dOpW8vDyio6N555136Nev3wXrBAUFMXDgQLp3786zzz5Lq1atuOeee4iOjmb8+PH07t37ovufP38+M2fOpGfPnnTr1o1FixbV7A8lylTrGvBKKS/gV2Aq8F8gTGttVUoNAF7RWo9USi03H29USrkAZ4AQ4HkArfVfzH0tB14xd/2K1nqkWf6CWfYWkFrZa1yqjnIN+KunyGJjya7TzN2YwK6kbJq5u/Dw4LY8NrR9k5uYsbbt37+fLl26OLoaVZKQkMAtt9zCnj17HF0VUUWVfb6uyjXgzdZDPNABoxVxFMjSWpce6EwCWpqPWwInAcwQyAaCzPJN5XZbfpuT55XHmttc7DWEA53KKmT+pkQWbD1JRn4JHUKb8fpt3bjjmgiauUs3nBBNUZX+52utbUAvpZQ/8ANQ2U+m0iZOZb1n+hLllR1qu9T6F1BKPQo8CtC6devKVhE1pLVm47F05m5IZMW+MwDc0KU5k66N5Nr2QTJCqwmLjIyUVomo3mgurXWWUmoN0B/wV0q5mC2HCCDZXC0JaAUkmYe5/ICMcuWlym9TWXnaJV7j/Hp9CnwKxmGu6rwncWn5xVZ+2H6KuRsTOHQ2jwAvVx4d0p4J/VsTESCTMQohDJcNE6VUCGAxg8QTuAGjY3w1cBewAJgElPZkLTafbzSXr9Jaa6XUYuArpdQ/gBZAFLAFowUSpZRqC5zC6KS/z9zmYq8hzmO3a5btOUN6fjGhPu6E+LgT6uNBiI/7FfVfHE/LZ+7GBL6LSyK32Er3lr789a5oxvRsIf0hQogLVKVlEg7MMftNnIBvtdZLlFL7gAVKqTeA7cBMc/2ZwDyl1BGMFslYAK31XqXUt8A+wAo8YR4+Qyk1DVgOOAOztNal4wenX+Q1RDnHUvN44d+72Xw8o9Llvh4uhPp6EOrjbtzMx6WBE+prlHu7ubDmUApzNiSy9lAqrs6K0T3CuX9AJNe09pdDWUKIi7psmGitdwEXjLXTWh8DLhi3p7UuAu4+v9xc9ibwZiXlS4GlVX0NYbDY7Hy67hjvrTyMh4sTb9/Zg+s6h5KSU0xqrnFLyS0iJbeYlBzjcVxiJim5xZRY7Rfsz9VZYbFpQn3c+cMNHRkX24pQH7nuuhDi8mToTQO182QW07/fxYEzudzcI5yXb+1a9sV/uQDQWpNTaD0XNLlFpOQUk55fQo+WfozqHoars0woLYSoOvnGaGAKSqy8vmQfd8z4jcyCEj6d2IcPx19TrRaEUgo/L1eimvswsEMwd/SOYMrQ9rw4ugtjeraQIBH1hiOvZ/KPf/yDrl27Eh0dzfDhw0lMTCxbNmfOHKKiooiKimLOnDll5S+99BKtWrWiWbOKE5meOHGC6667jt69exMdHc3SpRcciGnwpGXSgKw9lMpLP+wmKbOQCf1b89yozvh6uDq6WqKuLXsezuyu3X2G9YCb3qrdfdax0i/ghIQEZsyYweOPP16t7W02G87OVR880rt3b+Li4vDy8uKjjz7iueee45tvviEjI4NXX32VuLg4lFL06dOHW2+9lYCAAMaMGcO0adOIioqqsK833niDe+65h6lTp7Jv3z5Gjx5dNrllYyE/QRuAjPwSnv5mB5NmbcHNxYmFjw3gjdt7SJCIOvXll1/Sr18/evXqxZQpU0hMTCQqKoq0tDTsdjuDBw9mxYoVJCQk0LlzZyZNmkR0dDR33XUXBQUFAMTHxzN06FD69OnDyJEjOX36NGC0OKZPn06/fv3o2LEj69evB4zZiceOHUt0dDT33nvvBdczSUtLq3A9k2effZY1a9Zwyy23lK03bdo0Zs+eXbbNa6+9xqBBg1i4cCFHjx5l1KhR9OnTh8GDB3PgwIGLvv/rrrsOLy9j+Hv//v3LJrhcvnw5I0aMIDAwkICAAEaMGMFPP/1Utl75mZFLKaXIyTGuSZOdnU2LFi2u6N+kPpOWST2mtWbxzmRe/XEfOYUWnry+A49f10GG5jY1DmhByPVMKpo5cyY33XQTAKdOnaJVq3OnxkVERHDq1KlLbv/KK69w44038sEHH5Cfn88vv/xy2ddsaCRM6qmkzAL+9z97WHMwlV6t/Hnrzh50DvN1dLVEEyHXMznnyy+/JC4ujrVr1wLGj7zzXW7Y/Ndff80DDzzAH//4RzZu3MjEiRPZs2cPTk6N5+CQhEk9Y7Nr5m5M4K/LDwLw8piu3D8gEmcnOcdDXD1yPRPDL7/8wptvvsnatWvL6hsREVGhNZSUlMSwYcMuuZ+ZM2eWHQobMGAARUVFpKWlERoaWuW61HeNJxYbuCKLja0JGdz50QZe/XEf/doGsuIPQ3hwYFsJEnHVyfVMYPv27UyZMoXFixdX+NIfOXIkK1asIDMzk8zMTFasWMHIkZeczJzW/9/euYdXVV0J/LeACPKUFGKAGIhtJMIAAawIUgZKi6BfBRUojh1BKyJDR2VGwIplGItaRUGmzjfqSEVHqcyAKDgVmGFURBQQLChPAaGCgBAeATEQyJo/9r7hEO7NTXIfScj6fV++u+86+6y9su65Z539uHtlZhbbtWnTJgoKCmjevHmp51Q3rGdSCRw5cYqNuC3RBQAAENNJREFUe/PZ+LX72/B1PtsOHOdMkZLa4CJmDMvlxk4t7RfnRqURzGdSVFRESkoK06ZNY/Xq1Xz44YfUrl2befPm8dJLL9GnT5/ifCajRo0iOzv7nHwm9957L0ePHuX06dPcf//9tG8fOQ3x6NGjueOOO+jYsSO5ublR85kMGDCAqVOnFuczyc7OjprPZPTo0UyZMoXCwkKGDRtGp06dwtYdN24cx48fLx4Wy8zMZMGCBaSmpvKb3/ymeAhw0qRJpKamAjB+/Hhmz57NiRMnyMjI4K677mLy5Mk8/fTTjBw5kunTpyMizJo164L7fpcrn0l1oCrlM1FV9hz5rjhghALIniNnV6ikN65Hu5aNadeiMe1bNqbH95vRpL6t0qrpWD4TI5FUWj4To2zsO1rAiu0HzwkeR78rBEAELm/WgC6tm/K33VvTvmVjrmzRmGYN61ay1YZhGLFjwSQOFPlJ8ycWbeG7wjPUrVOLnPRGXN+hBe1auh5HTnoj6l9k7jYuPKp7PpNHH320eB4lxJAhQ5g4cWIlWVQ9sbtbjOzK+5Zxc9ez6stD9G7bnPHX5XDFpQ2pY1uSGEa1YOLEiRY44oAFkwpSVKS8/NFOnly0hTq1hScHd2RI14wLblLNMAyjLFgwqQA7D37L+LnrWbXzEH3aNuexmzvQosnFlW2WYRhGpWHBpBwUFSmzVuzkycWbSaldi6eGdOKWLq2sN2IYRo3HgkkZ2XnwW8bNXcfqnYf5cU4aj93UgfQmljjKMAwD7BfwUSkqUmYu/5L+M5axed8xnhrSiZnDr7JAYhhJoKbmM1m1ahW9e/cmOzubLl26cMMNN/DZZy4NweTJk2nVqhW5ubnk5OQwevTo4u1kRowYQVZWFrm5uXTp0iXiVjaJIGrPREQuA14B0oEi4AVVnSEic4C2vtolwBFVzRWRNsAmYIs/9rGq3uN1dQVmARfj0vTep6oqIqnAHKANsBMYqqqHxY0fzQCuB04AI1R1bYz/c5n58uC3jLfeiFHJPLHqCTYfirxVekXISc1hwtUT4qoz0dSUfCb79+9n6NChzJ49mx49egCwfPlytm/fTocOHQAYO3YsDzzwAEVFRfTq1Yv333+fPn36ADB16lQGDx7MkiVLGDVqVNgtaRJBWXomp4F/VNUrgWuAMSLSTlV/rqq5qpoLzAPeCJyzPXQsFEg8/wbcDWT7v/5e/iCwVFWzgaX+PcCAQN27/fkJ50yR8uIHO+j/zDK27DvGtKHWGzFqHpbPpHLymTz77LMMHz68OJAA9OzZk0GDBp1X99SpUxQUFNC0adPzjvXq1Ytt27ZFbCfeRO2ZqOpeYK8vHxORTUArYCOA7z0MBX5cmh4RaQE0VtWP/PtXgEHAO8BAoLev+jLwHjDBy19Rt+fLxyJyiYi08DYlhB0HjjNu7nrW7DpM35w0Hru5A5c2tiBiVB6V0YOwfCbnksx8Jhs2bGD48OGl6ps+fTqvvvoqu3btYsCAAeTm5p5XZ+HChcU9mWRQrgl4P4TVGVgZEP8I2K+qXwRkWSLyKZAPPKyqH+AC0O5And1eBnBpKECo6l4RCW3R2Qr4Ksw55wQTEbkb13MhMzOzPP8SJ06dZuv+42zdd4wNXx/l9dVfUbdOLaYN7cRNnW2lllEzsXwmZ6nsfCbdunUjPz+ffv36MWPGDODsMFdhYSGDBw/m9ddfZ9iwYYDboHLKlCk0b96cmTNnRtUfL8ocTESkIW44635VzQ8cuhX4Y+D9XiBTVfP8HMmbItIeCOftaLtMlukcVX0BeAHcRo/hFJ0pUnbmfcvmvcfYsi+fzfuOsWX/Mf5y6ASha+PilNr0vTKNyT9rT5r1RowajOUzcVRGPpP27duzdu1aBg4cCMDKlSuZO3cub7/99nl1U1JS6N+/P8uWLSsOJqE5k2RTpmAiIim4QPKaqr4RkNcBbga6hmSqehI46ctrRGQ7cAWuV5ERUJsBfO3L+0PDV3447Bsv3w1cFuGciOzPL3DBIhQ09h1j2zfHOXnaXXC1BNo0a0D7lo25uXMGbdMbkZPeiMzU+tSy3CGGQd++fRk4cCBjx44lLS2NQ4cOcezYMZ566iluu+02WrduzciRI4tvcKF8Jt27dw+bz6R79+4UFhaydevWUregD+Uz6dOnT4XymRQUFLB06VJ69ux53nnBfCZDhgxBVVm/fn3ELehD+UwWLVp0Xj6Thx56iMOHDwOwZMmS84JuSUL5TEaMGBE1n8mYMWPo1q0b1113XfG8SWgOqiSqyooVK8IOcyWbsqzmEmAmsElVp5U4/BNgs6ruDtRvDhxS1TMicjlu8nyHqh4SkWMicg1umOx24Pf+tAXAcOB3/vWtgPxXIvI60A04Gm2+ZOPefLo9djY5TlqjurRNb8Tt3VvTNt1tuPiDtIaWR90wSsHymVRePpP09HTmzJnDhAkT2LNnD2lpaTRr1oxJkyYV1wnNmRQWFtKxY8dyr2xLBFHzmYhIT+AD4DPc0mCAh1T1TyIyC7f097lA/VuAR3CrwM4A/6SqC/2xqzi7NPgd4O/90uDvAf8JZAJ/AYb44CPAs7hVXyeAO1S11GQlLX7QXh9/+W3apjembXojUhtcVHZvGEYVwfKZGImkUvKZqOpyws9doKojwsjm4YbEwtX/BPirMPI8oG8YuQJjotkYpNUlFzPi2qzynGIYhmHEiG2nYhhGTFg+k4qxePFiJkw4d9l3VlYW8+fPT2i7icLS9hpGFWTTpk3k5OTY0nQj7qgqmzdvjvswl+3NZRhVkHr16pGXlxf2Nw2GUVFUlby8POrVi/9PH2yYyzCqIBkZGezevZsDBw5UtinGBUa9evXIyMiIXrGcWDAxjCpISkoKWVm2kMSoPtgwl2EYhhEzFkwMwzCMmLFgYhiGYcTMBbc0WEQOALtKqdIMOJgkcyqC2RcbVdm+qmwbmH2xUt3ta62q4TcMKwMXXDCJhoh8Esta6kRj9sVGVbavKtsGZl+s1HT7bJjLMAzDiBkLJoZhGEbM1MRg8kJlGxAFsy82qrJ9Vdk2MPtipUbbV+PmTAzDMIz4UxN7JoZhGEacsWBiGIZhxI6qVqs/4A+4HPGfB2SdgI9w2SAXAo29/CLgJS9fB/T28kbAnwN/B4FnwrTVBvguUO+5KLZdBrwLbAI2APd5eSrwP8AX/rWplwvwL8A2YD3QJaBruK//BTA8Qnth9SbaPiDX+3uDl/88QnsjgAMB/92VRP+dCbS7IEJ7dYE5/vyVQJsk+a9PieuvABhUCf7L8Z/jSeCBErr6A1u87Q/G6r942RZJT5j2egNHA76blETf7cTdc/4MfBKhvYjXboL917bEtZcP3B+r/1S1WgaTXkAXzg0mq4G/9uU7gd/68hjgJV9OA9YAtcLoXAP0CiNvE2ynDLa14OwNoxGwFWgHPIn/QgIPAk/48vW49MUCXAOsDFwgO/xrU18+L1BE0psE+64Asn25JbAXuCRMeyOAZ5PtP3/seBna+zv8AwIwDJiTLPsCOlOBQ0D9SvBfGvBD4FHOveHUBrYDl+MeyNYB7WLxXxxtC6snTHu9gbeT7Tt/bCfQLEp7Ua+NRNlX4nPeh/uxYkz+U62GwcT/o204N5jkc3YxwWXARl/+V+AXgXpLgatL6MoGvgqdX1o7FbDzLeCnuCe8FoGLYosvPw/cGqi/xR+/FXg+ID+nXsn6JfUm2r4wetbhg0sJ+QjKcTOMp32ULZgsBrr7ch1cD/W86yCR/gPuBl6LoD+h/gvUm8y5N+zuwOLA+18Dv46n/ypqWyQ9YeS9KefNMF72UbZgUqbvViL9B/QDPoxwrNz+u1DmTD4HbvTlIbiAAu4mN1BE6ohIFtA1cCzErbgnKo2gO0tEPhWR90XkR2U1SETaAJ1x3f9LVXUvgH9N89Va4QJZiN1eFklekkh6E21fUM/VuKfX7RGaukVE1ovIXBEp6ftE2ldPRD4RkY9FZFCEZorPV9XTuG7995JkX4hhwB9LaSqR/otEWa+/CvkvRtsi6QlHdxFZJyLviEj7CuqtiH0KLBGRNSJyd4Q6ZfVxIuwLEe3aK5f/LpRgcicwRkTW4LqAp7z8D7gP6RPgGWAFcLrEuaU5dC+QqaqdgX8AZotI42jGiEhDYB5uLDK/tKphZFqKPC7Ewb6QnhbAfwB3qGpRmLoLcePoHYH/BV5Oon2Z6raO+BvgGRH5fjnPT7R9If91wD3hhyPR/ouoIowsnF/K7b842FZWPWtxwzedgN8Db8ZJb1m4VlW7AANw96Ve4ZoKI4vntRdNz0W4B/D/ilCl3P67IIKJqm5W1X6q2hUXGLZ7+WlVHauquao6ELgEN1EFgIh0Auqo6poIek+qap4vr/F6ryjNFhFJwX3Yr6nqG1683984QjeQb7x8N+f2lDKAr0uRlySS3kTbhw+q/w08rKofh2tLVfNU9aR/+++4nmFS7FPV0OsO4D3ck1xJis8XkTpAE9z8RcLt8wwF5qtqYbi2kuC/SJT1+iuX/+JkWyQ956Cq+ap63Jf/BKSISLMK6C23fYFr7xtgPnB1mGpl9XHc7fMMANaq6v4I/0O5/XdBBBMRSfOvtYCHgef8+/oi0sCXfwqcVtWNgVNvpZRunog0F5Havnw5bn5lRyn1BZgJbFLVaYFDC3Crs/CvbwXkt4vjGuCo76ouBvqJSFMRaYob2wz39BpJb0Lt808184FXVDXSk03o4g5xI24lSjLsayoidb3OZsC1QPBzD6d3MPB/pQx3xvPzDRHt+ku0/yKxGsgWkSz/WQ/zOkpSZv/Fy7ZS9JSsl+7rhoZiawF5FdBbXvsaiEijUBn33f08TNVo10ZC7AsQ7dorl/+A6jcB7x2wFyjERfdfAvfhVjdsBX7H2cn4NrgJqk24YYLWJXTtAHJKyG4EHvHlW3DL8Nbhun0/i2JbT1xXdT1nl9RdjxtHXorrFS0FUn19wS0S2I5bSnhVQNeduGWD23DDSCH5i6F6kfQm2j7gF97/wSWGuf7YI8CNvvx4wH/vlvR1Au3rwdnl4J8Bvwy0EbSvHq6bvw1YBVyexM+3DbCHEqsLk+y/dNx3KB844suhZfXX475P24GJsfovXrZF0uPPuQe4x5d/FfDdx0CPZPgOtwJunf/bUMJ3QfsiXhtJ+Gzr4wJDkxJtVNh/qmrbqRiGYRixc0EMcxmGYRiViwUTwzAMI2YsmBiGYRgxY8HEMAzDiBkLJoZhGEbMWDAxDMMwYsaCiWFUQUI/ljWM6oIFE8OIERH5rYjcF3j/qIjcKyLjRGS1uI0a/zlw/E1xmwBukMBGgCJyXEQeEZGVuJ17DaPaYMHEMGJnJn5LC7+lzzBgP277natxycS6Bjb8u1PdPnJXAfeKSGin3Qa4lAfdVHV5Mv8Bw4iVOpVtgGFUd1R1p4jkiUhn4FLgU1xion6+DNAQF1yW4QLITV5+mZfn4bJDzkum7YYRLyyYGEZ8eBGXzCodl/qgL/C4qj4frCQivYGf4JJKnRCR93B7XAEUqOqZZBlsGPHEhrkMIz7Mx+VN/yFuh+fFwJ3i8k8gIq387tZNgMM+kOTgUrYaRrXHeiaGEQdU9ZSIvAsc8b2LJSJyJfCR38n7OG635UXAPSKyHrejddhcMIZR3bBdgw0jDviJ97XAEFX9Ilp9w7jQsGEuw4gREWmHy+mx1AKJUVOxnolhGIYRM9YzMQzDMGLGgolhGIYRMxZMDMMwjJixYGIYhmHEjAUTwzAMI2b+H8WaGydOTPhDAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# You can see from this plot that GBP were worth more than USD on Dec. 31, 2018\n",
+    "# (by about 1.3x, it appears)\n",
+    "(data_constant_pounds\n",
+    " .loc[data_constant_pounds['store_type'] == 'grocery_stores', :]\n",
+    " .set_index('year')\n",
+    " .drop(columns='store_type')\n",
+    " .plot())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/notebooks/inflating_converting_currency.ipynb
+++ b/examples/notebooks/inflating_converting_currency.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "This notebook serves to show a brief and simple example of how to use the `convert_currency()` and `inflate_currency()` methods from pyjanitor's finance submodule.\n",
     "\n",
-    "The data for this example notebook come from the [United States Department of Agriculture Economic Research Service](https://www.ers.usda.gov/data-products/food-expenditure-series/), and we are specifically going to download the data of nominal food and alcohol expenditures, with taxes and tips, for all purchasers.  The data set includes nominal expenditures for 1997-2018, and the expenditures are provided in U.S. dollars for the year in the which the expenditures were made.  For example, the expenditure values for 1997 are in units of 1997 U.S. dollars, whereas expenditures for 2018 are in 2018 U.S. dollars."
+    "The data for this example notebook come from the [United States Department of Agriculture Economic Research Service](https://www.ers.usda.gov/data-products/food-expenditure-series/), and we are specifically going to download the data of nominal food and alcohol expenditures, with taxes and tips, for all purchasers.  The data set includes nominal expenditures for 1997-2018, and the expenditures are provided in **millions** of U.S. dollars for the year in the which the expenditures were made.  For example, the expenditure values for 1997 are in units of 1997 U.S. dollars, whereas expenditures for 2018 are in 2018 U.S. dollars."
    ]
   },
   {


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request: 

- Added an example notebook for the `convert_currency()` and `inflate_currency()` methods in the finance submodule (uses USDA expenditure data).

**This PR resolves #503.**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:master, but rather from `<your_username>`:<branch_name>.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
(Already on the authors list)
3. [x] Add a line to `CHANGELOG.rst` under the latest version header (i.e. the one that is "on deck") describing the contribution.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [x] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - pycodestyle checking
    - running the test suite
    - docs build
    
Once done, please check off the check-box above.
    
If `make check` does not work for you, you can execute the commands listed in the Makefile individually.

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
