### PR TITLE
[ENH] Add decorators to skip nans and errors in iteration

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -78,6 +78,7 @@ Contributors
 - `@puruckertom <https://github.com/puruckertom>`_ | `contributions <https://github.com/ericmjl/pyjanitor/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Apuruckertom>`_
 - `@thomasjpfan <https://github.com/thomasjpfan>`_ | `contributions <https://github.com/ericmjl/pyjanitor/issues?q=is%3Aclosed+mentions%3Athomasjpfan>`_
 - `@jiafengkevinchen <https://github.com/jiafengkevinchen>`_ | `contributions <https://github.com/ericmjl/pyjanitor/pull/480#issue-298730562>`_
+    - `<https://github.com/ericmjl/pyjanitor/issues/549>`_
 - `@mralbu <https://github.com/mralbu>`_ | `contributions <https://github.com/ericmjl/pyjanitor/issues/502>`_
 - `@anzelpwj <https://github.com/anzelpwj>`_ | `contributions <https://github.com/qtson/pyjanitor/pulls?utf8=%E2%9C%93&q=is%3Aclosed+mentions%3anzelpwj>`_
 - `@Ram-N <https://github.com/Ram-N>`_ | `contributions <https://github.com/ericmjl/pyjanitor/pulls?utf8=%E2%9C%93&q=is%3Aclosed+mentions%3ARam-N>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ release_number (on deck)
    help when a few tests failed for `win32`
 - [ENH] Pyjanitor for PySpark @zjpoh
 - [ENH] Add pyspark clean_names @zjpoh
+- [ENH] Add decorator functions for missing and error handling @jiafengkevinchen
 
 v0.18.1
 =======

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -347,7 +347,7 @@ def skiperror(
     def _wrapped(x, *args, **kwargs):
         try:
             return f(x, *args, **kwargs)
-        except:
+        except Exception:
             if return_x:
                 return x
             return return_val

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -4,6 +4,7 @@ import functools
 import warnings
 from typing import Callable, Dict, List, Union
 
+import numpy as np
 import pandas as pd
 
 from .errors import JanitorError
@@ -289,3 +290,66 @@ def check_column(
                 raise ValueError(
                     f"{column_name} already present in dataframe columns!"
                 )
+
+
+def skipna(f: Callable) -> Callable:
+    """
+    Decorator for escaping np.nan and None in a function
+
+    Should be used like this::
+
+        df[column].apply(skipna(transform))
+
+    or::
+
+        @skipna
+        def transform(x):
+            pass
+
+    :param f: the function to be wrapped
+    :returns: _wrapped, the wrapped function
+    """
+
+    def _wrapped(x, *args, **kwargs):
+        if (type(x) is float and np.isnan(x)) or x is None:
+            return np.nan
+        else:
+            return f(x, *args, **kwargs)
+
+    return _wrapped
+
+
+def skiperror(
+    f: Callable, return_x: bool = False, return_val=np.nan
+) -> Callable:
+    """
+    Decorator for escaping errors in a function
+
+    Should be used like this::
+
+        df[column].apply(
+            skiperror(transform, return_val=3, return_x=False))
+
+    or::
+
+        @skiperror(return_val=3, return_x=False)
+        def transform(x):
+            pass
+
+    :param f: the function to be wrapped
+    :param return_x: whether or not the original value that caused error
+        should be returned
+    :param return_val: the value to be returned when an error hits.
+        Ignored if return_x is True
+    :returns: _wrapped, the wrapped function
+    """
+
+    def _wrapped(x, *args, **kwargs):
+        try:
+            return f(x, *args, **kwargs)
+        except:
+            if return_x:
+                return x
+            return return_val
+
+    return _wrapped

--- a/tests/utils/test_skiperror.py
+++ b/tests/utils/test_skiperror.py
@@ -8,14 +8,13 @@ import pytest
 @pytest.mark.functions
 def test_skiperror():
     df = pd.DataFrame({"x": [1, 2, 3, "a"], "y": [1, 2, 3, "b"]})
-    func = lambda s: s + 1
+
+    def func(s):
+        return s + 1
 
     # Verify that applying function causes error
-    try:
+    with pytest.raises(Exception):
         df["x"].apply(func)
-        assert False
-    except:
-        pass
 
     result = df["x"].apply(skiperror(func))
     assert (result.values[:-1] == np.array([2, 3, 4])).all() and np.isnan(

--- a/tests/utils/test_skiperror.py
+++ b/tests/utils/test_skiperror.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from janitor.utils import skiperror
+import numpy as np
+
+import pytest
+
+
+@pytest.mark.functions
+def test_skiperror():
+    df = pd.DataFrame({"x": [1, 2, 3, "a"], "y": [1, 2, 3, "b"]})
+    func = lambda s: s + 1
+
+    # Verify that applying function causes error
+    try:
+        df["x"].apply(func)
+        assert False
+    except:
+        pass
+
+    result = df["x"].apply(skiperror(func))
+    assert (result.values[:-1] == np.array([2, 3, 4])).all() and np.isnan(
+        result.values[-1]
+    )
+
+    result = df["x"].apply(skiperror(func, return_x=True))
+    assert (result.values == np.array([2, 3, 4, "a"], dtype=object)).all()
+
+    result = df["x"].apply(skiperror(func, return_x=False, return_val=5))
+    assert (result.values == np.array([2, 3, 4, 5])).all()

--- a/tests/utils/test_skipna.py
+++ b/tests/utils/test_skipna.py
@@ -8,14 +8,13 @@ import pytest
 @pytest.mark.functions
 def test_skipna():
     df = pd.DataFrame({"x": ["a", "b", "c", np.nan], "y": [1, 2, 3, np.nan]})
-    func = lambda s: s + "1"
+
+    def func(s):
+        return s + "1"
 
     # Verify that applying function causes error
-    try:
+    with pytest.raises(Exception):
         df["x"].apply(func)
-        assert False
-    except:
-        pass
 
     result = df["x"].apply(skipna(func))
     assert (

--- a/tests/utils/test_skipna.py
+++ b/tests/utils/test_skipna.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from janitor.utils import skipna
+import numpy as np
+
+import pytest
+
+
+@pytest.mark.functions
+def test_skipna():
+    df = pd.DataFrame({"x": ["a", "b", "c", np.nan], "y": [1, 2, 3, np.nan]})
+    func = lambda s: s + "1"
+
+    # Verify that applying function causes error
+    try:
+        df["x"].apply(func)
+        assert False
+    except:
+        pass
+
+    result = df["x"].apply(skipna(func))
+    assert (
+        result.values[:-1] == np.array(["a1", "b1", "c1"])
+    ).all() and np.isnan(result.values[-1])


### PR DESCRIPTION
# PR Description

- Implements the functions proposed in #549 
- Provides decorators `.utils.skipna` and `.utils.skiperror` for skipping np.nan and errors

**This PR resolves #549 **

1. [x ] PR in from a fork off your branch. Do not PR from `<your_username>`:master, but rather from `<your_username>`:<branch_name>.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
3. [x] Add a line to `CHANGELOG.rst` under the latest version header (i.e. the one that is "on deck") describing the contribution.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
