### PR TITLE
[ENH] Change morgan_fingerprints to use chirality by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ release_number (on deck)
 - [ENH] Add decorator functions for missing and error handling @jiafengkevinchen
 - [DOC] Update README with functional ``pandas`` API example.
 - [INF] Move ``get_features_targets()`` to new ``ml.py`` module by @hectormz
+- [ENH] Add chirality to morgan fingerprints in janitor.chemistry submodule by @Clayton-Springer
 
 v0.18.1
 =======

--- a/janitor/chemistry.py
+++ b/janitor/chemistry.py
@@ -244,12 +244,12 @@ def morgan_fingerprint(
 
     if kind == "bits":
         fps = [
-            GetMorganFingerprintAsBitVect(m, radius, nbits)
+            GetMorganFingerprintAsBitVect(m, radius, nbits, useChirality=True)
             for m in df[mols_column_name]
         ]
     elif kind == "counts":
         fps = [
-            GetHashedMorganFingerprint(m, radius, nbits)
+            GetHashedMorganFingerprint(m, radius, nbits, useChirality=True)
             for m in df[mols_column_name]
         ]
 


### PR DESCRIPTION
This PR closes #558.

Changes made:

* We added `useChirality=True`.
* We do not surface this as an option to end-users because this should be on by default.