### PR TITLE
[ENH] Add functionality to deconcatenate tuple/list/collections in a column to deconcatenate_column

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ new version (on deck)
 =====================
 - [ENH] Series toset() functionality #570
 - [ENH] Added option to coalesce function to not delete coalesced columns.
+- [ENH] Added functionality to deconcatenate tuple/list/collections in a column to deconcatenate_column
 
 v0.18.2
 =======

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -895,7 +895,16 @@ def deconcatenate_column(
     De-concatenates a single column into multiple columns. The column to
     de-concatenate can be either a collection (list, tuple, ...) which can be
     separated out with ``pd.Series.tolist()`` or a string to slice based on
-    ``sep``.
+    De-concatenates a single column into multiple columns. 
+    The column to de-concatenate can be either a collection (list, tuple, ...) 
+    which can be separated out with ``pd.Series.tolist()``,
+    or a string to slice based on ``sep``.
+    To determine this behaviour automatically,
+    the first element in the column specified is inspected.
+    If it is a string, then ``sep`` must be specified.
+    Else, the function assumes that it is an iterable type
+    (e.g. ``list`` or ``tuple``),
+    and will attempt to deconcatenate by splitting the list.
 
     Given a column with string values, this is the inverse of the
     ``concatenate_columns`` function.

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -892,9 +892,6 @@ def deconcatenate_column(
     preserve_position: bool = False,
 ) -> pd.DataFrame:
     """
-    De-concatenates a single column into multiple columns. The column to
-    de-concatenate can be either a collection (list, tuple, ...) which can be
-    separated out with ``pd.Series.tolist()`` or a string to slice based on
     De-concatenates a single column into multiple columns.
     The column to de-concatenate can be either a collection (list, tuple, ...)
     which can be separated out with ``pd.Series.tolist()``,

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -895,8 +895,8 @@ def deconcatenate_column(
     De-concatenates a single column into multiple columns. The column to
     de-concatenate can be either a collection (list, tuple, ...) which can be
     separated out with ``pd.Series.tolist()`` or a string to slice based on
-    De-concatenates a single column into multiple columns. 
-    The column to de-concatenate can be either a collection (list, tuple, ...) 
+    De-concatenates a single column into multiple columns.
+    The column to de-concatenate can be either a collection (list, tuple, ...)
     which can be separated out with ``pd.Series.tolist()``,
     or a string to slice based on ``sep``.
     To determine this behaviour automatically,

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -990,7 +990,7 @@ def deconcatenate_column(
 
     if new_column_names is None and autoname is None:
         raise ValueError(
-            "One of `new_column_names` or `autoname` must be " "suppled."
+            "One of `new_column_names` or `autoname` must be supplied."
         )
 
     if autoname:

--- a/tests/utils/test_skiperror.py
+++ b/tests/utils/test_skiperror.py
@@ -1,8 +1,8 @@
-import pandas as pd
-from janitor.utils import skiperror
 import numpy as np
-
+import pandas as pd
 import pytest
+
+from janitor.utils import skiperror
 
 
 @pytest.mark.functions

--- a/tests/utils/test_skipna.py
+++ b/tests/utils/test_skipna.py
@@ -1,8 +1,8 @@
-import pandas as pd
-from janitor.utils import skipna
 import numpy as np
-
+import pandas as pd
 import pytest
+
+from janitor.utils import skipna
 
 
 @pytest.mark.functions


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request: 

- `deconcatenate_column` now contains logic to handle splitting collections like tuples / lists on top of splitting strings

**This PR resolves *nothing*.**

# PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
<!-- We'd like to acknowledge your contributions! -->
3. [x] Add a line to `CHANGELOG.rst` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [x] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - pycodestyle checking
    - running the test suite
    - docs build
    
## Code Changes

<!-- If you have not made code changes, please feel free to delete this section. -->

If you are adding code changes, please ensure the following:

- [x] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [x] Check to ensure that test coverage covers the lines of code that you have added.
    - [x] Ensure that all tests pass.


# Relevant Reviewers

- @ericmjl
