### PR TITLE
[ENH] Fix error message when length of new_column_names is wrong

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,4 +84,4 @@ Contributors
 - `@Ram-N <https://github.com/Ram-N>`_ | `contributions <https://github.com/ericmjl/pyjanitor/pulls?utf8=%E2%9C%93&q=is%3Aclosed+mentions%3ARam-N>`_
 - `@eyaltrabelsi <https://github.com/eyaltrabelsi>`_ | `contributions <https://github.com/ericmjl/pyjanitor/pulls?q=is%3Aclosed+mentions%3A eyaltrabelsi>`_
 - `@gddcunh <https://github.com/gddcunh>`_ | `contributions <https://github.com/ericmjl/pyjanitor/pulls?q=is%3Aclosed+mentions%3A gddcunh>`_
-
+- `@DollofCuty <https://github.com/DollofCuty>`_ | `contributions <https://github.com/qtson/pyjanitor/pulls?utf8=%E2%9C%93&q=is%3Aclosed+mentions%3ADollofCuty>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ new version (on deck)
 =====================
 - [ENH] Series toset() functionality #570
 - [ENH] Added option to coalesce function to not delete coalesced columns.
+- [ENH] Fix error message when length of new_column_names is wrong
 
 v0.18.2
 =======

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -968,7 +968,7 @@ def deconcatenate_column(
         ]
     if not len(new_column_names) == deconcat.shape[1]:
         raise JanitorError(
-            f"you need to provide {len(new_column_names)} names"
+            f"you need to provide {len(deconcat.shape[1])} names "
             "to new_column_names"
         )
 


### PR DESCRIPTION
# PR Description

Now it actually prints the length you need to provide instead of the length that was wrongly provided

**This PR resolves #541 .**

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
3. [x] Add a line to `CHANGELOG.rst` under the latest version header (i.e. the one that is "on deck") describing the contribution.

## Quick Check

- [x] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - pycodestyle checking
    - running the test suite
    - docs build

## Code Changes

- [x] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [x] Check to ensure that test coverage covers the lines of code that you have added.
    - [x] Ensure that all tests pass.

# Relevant Reviewers

- @ericmjl
