### PR TITLE
[DOC] Fix command formatting in CONTRIBUTING.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ new version (on deck)
 - [DOC] Fix #noqa comments showing up in docs by @hectormz
 - [ENH] Add unionizing a group of dataframes' categoricals. @zbarry
 - [DOC] Fix contributions hyperlinks in ``AUTHORS.rst`` and contributions by @hectormz
+- [INF] Add ``pre-commit`` hooks to repository by @ericmjl
+- [DOC] Fix formatting code in ``CONTRIBUTING.rst``
 
 v0.18.2
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ new version (on deck)
 - [ENH] Add unionizing a group of dataframes' categoricals. @zbarry
 - [DOC] Fix contributions hyperlinks in ``AUTHORS.rst`` and contributions by @hectormz
 - [INF] Add ``pre-commit`` hooks to repository by @ericmjl
-- [DOC] Fix formatting code in ``CONTRIBUTING.rst``
+- [DOC] Fix formatting code in ``CONTRIBUTING.rst`` by @hectormz
 
 v0.18.2
 =======

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,7 +38,7 @@ This also installs your new conda environment as a Jupyter-accessible kernel. To
 4. (Optional) Install the pre-commit hooks.
 
 As of 29 October 2019, pre-commit hooks are available to run code formatting checks automagically
-before git commits happen. If you did not have these installed before, run the following commands:
+before git commits happen. If you did not have these installed before, run the following commands::
 
     # Update your environment to install pre-commit
     $ conda env update -f environment-dev.yml


### PR DESCRIPTION
<!-- Thank you for your PR!

BEFORE YOU CONTINUE! Please add the appropriate three-letter abbreviation to your title.

The abbreviations can be:
- [DOC]: Documentation fixes.
- [ENH]: Code contributions and new features.
- [TST]: Test-related contributions.
- [INF]: Infrastructure-related contributions.

Also, do not forget to tag the relevant issue here as well.

Finally, as commits come in, don't forget to regularly rebase!
-->

# PR Description

Please describe the changes proposed in the pull request:

- New codeblock on installing `pre-commit` isn't formatted correctly.

<!-- Doing so provides maintainers with context on what the PR is, and can help us more effectively review your PR. -->

<!-- Please also identify below which issue that has been raised that you are going to close. -->

**This PR resolves #603 .**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [X] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - pycodestyle checking
    - running the test suite
    - docs build

Once done, please check off the check-box above.

If `make check` does not work for you, you can execute the commands listed in the Makefile individually.


## Documentation Changes

<!-- If you have not made documentation changes, please feel free to delete this section. -->

If you are adding documentation changes, please ensure the following:

- [X] Build the docs locally.
- [X] View the docs to check that it renders correctly.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
(I guess I didn't review closely enough!)
