### PR TITLE
[ENH] Enforced string column names by default when using clean_names.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ new version (on deck)
 =====================
 - [DOC] Edited transform_column dest_column_name kwarg description to be clearer on defaults by @evan-anderson.
 - [ENH] Replace ``apply()`` in favor of ``pandas`` functions in several functions. @hectormz
+- [ENH] Enforce string conversion when cleaning names. @ericmjl
 
 v0.19.0
 =======

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -17,6 +17,8 @@ from typing import (
     Tuple,
     Union,
 )
+from types import SimpleNamespace
+
 
 import numpy as np
 import pandas as pd
@@ -227,12 +229,16 @@ def clean_names(
     remove_special: bool = False,
     strip_accents: bool = True,
     preserve_original_columns: bool = True,
+    enforce_string: bool = True,
 ) -> pd.DataFrame:
     """
     Clean column names.
 
-    Takes all column names, converts them to lowercase, then replaces all
-    spaces with underscores.
+    Takes all column names, converts them to lowercase,
+    then replaces all spaces with underscores.
+
+    By default, column names are converted to string types.
+    This can be switched off by passing in ``enforce_string=False``.
 
     This method does not mutate the original DataFrame.
 
@@ -271,9 +277,15 @@ def clean_names(
         Only letters, numbers and underscores are preserved.
     :param preserve_original_columns: (optional) Preserve original names.
         This is later retrievable using `df.original_columns`.
+    :param enforce_string: Whether or not to convert all column names
+        to string type. Defaults to True, but can be turned off.
+        Columns with >1 levels will not be converted by default.
     :returns: A pandas DataFrame.
     """
     original_column_names = list(df.columns)
+
+    if enforce_string:
+        df = df.rename(columns=lambda x: str(x))
 
     df = df.rename(columns=lambda x: _change_case(x, case_type))
 

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -17,7 +17,6 @@ from typing import (
     Tuple,
     Union,
 )
-from types import SimpleNamespace
 
 
 import numpy as np

--- a/tests/functions/test_clean_names.py
+++ b/tests/functions/test_clean_names.py
@@ -161,3 +161,9 @@ def test_clean_names_camelcase_to_snake(dataframe):
         "snakes_on_a_plane2",
         "snakes_on_a_plane3",
     ]
+
+
+def test_clean_names_enforce_string(dataframe):
+    df = dataframe.rename(columns={"a": 1}).clean_names(enforce_string=True)
+    for c in df.columns:
+        assert isinstance(c, str)


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- Enforces string type for column names when calling `clean_names()`.
- Coercion is on by default; can be turned off by a flag.
- Docstring documents the behaviour of the function.

**This PR resolves #612.** 

# Relevant Reviewers

Happy to take comments from anybody tagged here :smile::

- @rahosbach 
- @zbarry 
- @szuckerman 
- @jk3587 
- @sallyhong 
- @shandou 
- @hectormz