### PR TITLE
[ENH] Implement find_replace API change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ new version (on deck)
 =====================
 - [DOC] Edited transform_column dest_column_name kwarg description to be clearer on defaults by @evan-anderson.
 - [ENH] Replace ``apply()`` in favor of ``pandas`` functions in several functions. @hectormz
+- [ENH] Change ``find_replace`` implementation to use keyword arguments to specify columns to perform find and replace on. @ericmjl
 
 v0.19.0
 =======

--- a/examples/notebooks/bad_values.ipynb
+++ b/examples/notebooks/bad_values.ipynb
@@ -519,16 +519,19 @@
     }
    ],
    "source": [
+    "mapping = {-9999.0: np.nan}\n",
     "wind2 = (\n",
     "    wind\n",
-    "    .find_replace('usgs_pr_id', {-9999.0: np.nan})\n",
-    "    .find_replace('p_tnum', {-9999.0: np.nan})\n",
-    "    .find_replace('p_cap', {-9999.0: np.nan})\n",
-    "    .find_replace('t_cap', {-9999.0: np.nan})\n",
-    "    .find_replace('t_hh', {-9999.0: np.nan})\n",
-    "    .find_replace('t_rd', {-9999.0: np.nan})\n",
-    "    .find_replace('t_rsa', {-9999.0: np.nan})\n",
-    "    .find_replace('t_ttlh', {-9999.0: np.nan})\n",
+    "    .find_replace(\n",
+    "        usgs_pr_id=mapping, \n",
+    "        p_tnum=mapping, \n",
+    "        p_cap=mapping,\n",
+    "        t_cap=mapping,\n",
+    "        t_hh=mapping,\n",
+    "        t_rd=mapping,\n",
+    "        t_rsa=mapping,\n",
+    "        t_ttlh=mapping,\n",
+    "    )\n",
     ")\n",
     "wind2.head()"
    ]
@@ -640,9 +643,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pyjanitor-dev",
    "language": "python",
-   "name": "python3"
+   "name": "pyjanitor-dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -654,9 +657,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -3039,7 +3039,20 @@ def find_replace(df, match: str = "exact", **mappings):
     pandas' ``df.replace()`` function provides the appropriate functionality.
     You can find more detail on the replace_ docs.
 
+    This function only works with column names that have no spaces
+    or punctuation in them.
+    For example, a column name ``item_name`` would work with ``find_replace``,
+    because it is a contiguous string that can be parsed correctly,
+    but ``item name`` would not be parsed correctly by the Python interpreter.
+
+    If you have column names that might not be compatible,
+    we recommend calling on ``clean_names()`` as the first method call.
+    If, for whatever reason, that is not possible,
+    then ``_find_replace()`` is available as a function
+    that you can do a pandas pipe_ call on.
+
     .. _replace: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.replace.html
+    .. _pipe: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.pipe.html
 
     :param df: A pandas DataFrame.
     :param match: Whether or not to perform an exact match or not.

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -3025,6 +3025,12 @@ def find_replace(df, match: str = "exact", **mappings):
             order={'coffee$': 'latte'},
         )
 
+    To perform a find and replace on the entire dataframe,
+    pandas' ``df.replace()`` function provides the appropriate functionality.
+    You can find more detail on the replace_ docs.
+
+    .. _replace: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.replace.html
+
     :param df: A pandas DataFrame.
     :param match: Whether or not to perform an exact match or not.
         Valid values are "exact" or "regex".

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -3029,7 +3029,7 @@ def find_replace(df, match: str = "exact", **mappings):
     pandas' ``df.replace()`` function provides the appropriate functionality.
     You can find more detail on the replace_ docs.
 
-    .. _replace: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.replace.html  # noqa: E501
+    .. _replace: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.replace.html
 
     :param df: A pandas DataFrame.
     :param match: Whether or not to perform an exact match or not.
@@ -3037,7 +3037,7 @@ def find_replace(df, match: str = "exact", **mappings):
     :param mappings: keyword arguments corresponding to column names
         that have dictionaries passed in indicating what to find (keys)
         and what to replace with (values).
-    """
+    """  # noqa: E501
     for column_name, mapper in mappings.items():
         df = _find_replace(df, column_name, mapper, match=match)
     return df

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -3029,7 +3029,7 @@ def find_replace(df, match: str = "exact", **mappings):
     pandas' ``df.replace()`` function provides the appropriate functionality.
     You can find more detail on the replace_ docs.
 
-    .. _replace: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.replace.html
+    .. _replace: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.replace.html  # noqa: E501
 
     :param df: A pandas DataFrame.
     :param match: Whether or not to perform an exact match or not.

--- a/tests/functions/test_find_replace.py
+++ b/tests/functions/test_find_replace.py
@@ -13,12 +13,12 @@ def df():
 @pytest.mark.functions
 def test_find_replace_single(df):
     assert df["a"].iloc[2] == 3
-    df.find_replace("a", {3: 5})
+    df.find_replace(a={3: 5})
     assert df["a"].iloc[2] == 5
 
     assert sum(df["c"] == 2) == 2
     assert sum(df["c"] == 5) == 0
-    df.find_replace("c", {2: 5})
+    df.find_replace(c={2: 5})
     assert sum(df["c"] == 2) == 0
     assert sum(df["c"] == 5) == 2
 
@@ -26,7 +26,7 @@ def test_find_replace_single(df):
 @pytest.mark.functions
 def test_find_replace_null_raises_error(df):
     with pytest.raises(ValueError):
-        df.find_replace("a", {np.nan: 5})
+        df.find_replace(a={np.nan: 5})
 
 
 @pytest.fixture
@@ -41,7 +41,7 @@ def df_orders():
 
 @pytest.mark.functions
 def test_find_replace_regex(df_orders):
-    df_orders.find_replace("order", {"coffee$": "latte"}, match="regex")
+    df_orders.find_replace(order={"coffee$": "latte"}, match="regex")
     assert df_orders["order"].iloc[0] == "latte"
     assert df_orders["order"].iloc[1] == "lemonade"
     assert df_orders["order"].iloc[-1] == "latte"
@@ -50,6 +50,4 @@ def test_find_replace_regex(df_orders):
 @pytest.mark.functions
 def test_find_replace_regex_match_rases_error(df_orders):
     with pytest.raises(ValueError):
-        df_orders.find_replace(
-            "order", {"lemonade": "orange juice"}, match="bla"
-        )
+        df_orders.find_replace(order={"lemonade": "orange juice"}, match="bla")

--- a/tests/functions/test_find_replace.py
+++ b/tests/functions/test_find_replace.py
@@ -48,6 +48,6 @@ def test_find_replace_regex(df_orders):
 
 
 @pytest.mark.functions
-def test_find_replace_regex_match_rases_error(df_orders):
+def test_find_replace_regex_match_raises_error(df_orders):
     with pytest.raises(ValueError):
         df_orders.find_replace(order={"lemonade": "orange juice"}, match="bla")


### PR DESCRIPTION
This PR now lets us `find_replace` using the following pattern:

```python
df = pd.DataFrame(...)

df = df.find_replace(column1={"hello": "world"}, column2={"what's up": "world"})
```

I have left out `find_replace_all`, because `df.replace()` natively fulfills this functionality.

This PR closes #255.

h/t @nickdelgrosso for the API change suggestion!