### PR TITLE
[INF] First attempt at a dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,51 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM continuumio/miniconda3
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Copy environment-dev.yml (if found) to a temp locaition so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment-dev.yml exists.
+COPY environment-dev.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git openssh-client less iproute2 procps iproute2 lsb-release \
+    #
+    # Install pylint
+    && /opt/conda/bin/pip install pylint \
+    #
+    # Update Python environment based on environment-dev.yml (if present)
+    && if [ -f "/tmp/conda-tmp/environment-dev.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment-dev.yml; fi \
+    && rm -rf /tmp/conda-tmp \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,11 +15,11 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python"
-	]
+	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "python --version",
+	"postCreateCommand": "python setup.py develop"
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.117.1/containers/python-3-miniconda
+{
+	"name": "Python 3 - Miniconda",
+	"context": "..",
+	"dockerFile": "Dockerfile",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/opt/conda/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/opt/conda/bin/pylint"
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python"
+	]
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "python --version",
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Python 3 - Miniconda",
 	"context": "..",
-	"image": "ericmjl/pyjanitor:devcontainer",
+	"image": "registry.hub.docker.com/ericmjl/pyjanitor:devcontainer",
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Python 3 - Miniconda",
 	"context": "..",
-	"dockerFile": "Dockerfile",
+	"image": "ericmjl/pyjanitor:devcontainer",
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/.devcontainer/noop.txt
+++ b/.devcontainer/noop.txt
@@ -1,0 +1,3 @@
+This file is copied into the container along with environment.yml* from the
+parent folder. This is done to prevent the Dockerfile COPY instruction from 
+failing if no environment.yml is found.

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - python setup.py develop
 
   # Build development container
-  - docker build -t ericmjl/pyjanitor:devcontainer .devcontainer/Dockerfile
+  - docker build -t ericmjl/pyjanitor:devcontainer -f .devcontainer/Dockerfile .
 
 # We use TravisCI to build docs and not run tests.
 # Tests are covered on Azure.

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ matrix:
     - python: 3.5  # we don't actually use this
       env: PYTHON_VERSION=3.7
 
+services:
+  - docker
+
 install:
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
@@ -28,6 +31,9 @@ install:
   - python -m ipykernel install --name pyjanitor-dev --user
   - python setup.py develop
 
+  # Build development container
+  - docker build -t ericmjl/pyjanitor:devcontainer .devcontainer/Dockerfile
+
 # We use TravisCI to build docs and not run tests.
 # Tests are covered on Azure.
 # Travis, however, has saner deploy syntax.
@@ -35,15 +41,21 @@ script:
   - make docs
 
 deploy:
-  provider: pages:git
-  deploy_key: $GITHUB_TOKEN
-  edge: true  # opt in to dpl v2
-  keep_history: false
-  cleanup: false
-  verbose: true
-  local_dir: docs/_build/html
-  on:
-    branch: dev
+  # Publish to github pages
+  - provider: pages:git
+    deploy_key: $GITHUB_TOKEN
+    edge: true  # opt in to dpl v2
+    keep_history: false
+    cleanup: false
+    verbose: true
+    local_dir: docs/_build/html
+    on:
+      branch: dev
+  # Push dev container to Dockerhub
+  - provider: script
+    script: bash scripts/docker_deploy.sh
+    on:
+      branch: dev
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/scripts/docker_deploy.sh
+++ b/scripts/docker_deploy.sh
@@ -1,0 +1,2 @@
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push ericmjl/pyjanitor:devcontainer


### PR DESCRIPTION
The purpose of this PR is to provide a development container that new users can opt in to use.

I have made the following choices:

1. We build the conda environment in the container on Travis, repeatedly and automatically. This way, nobody should need to build it locally.
1. Users can then pull the Docker container and develop code from within it.

This is all intended to work with VSCode Remote (Container) extension: https://code.visualstudio.com/docs/remote/containers